### PR TITLE
fix: Fix `to_quotes()` method to return Python object

### DIFF
--- a/stock_indicators/indicators/adl.py
+++ b/stock_indicators/indicators/adl.py
@@ -61,4 +61,4 @@ class ADLResults(IndicatorResults[ADLResult]):
     def to_quotes(self) -> Iterable[Quote]:
         quotes = CsIndicator.ConvertToQuotes(CsList(type(self._csdata[0]), self._csdata))
 
-        return quotes
+        return [ Quote.from_csquote(q) for q in quotes ]

--- a/stock_indicators/indicators/rsi.py
+++ b/stock_indicators/indicators/rsi.py
@@ -47,4 +47,4 @@ class RSIResults(IndicatorResults[RSIResult]):
     def to_quotes(self) -> Iterable[Quote]:
         quotes = CsIndicator.ConvertToQuotes(CsList(type(self._csdata[0]), self._csdata))
 
-        return quotes
+        return [ Quote.from_csquote(q) for q in quotes ]


### PR DESCRIPTION
## Description

 - Fix `to_quotes()` method to return Python object.

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
