### PR TITLE
docs: fix bad URLs on contributing page

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -30,9 +30,6 @@ exclude: [
   "*.yml", 
   "*.pptx",
   ".offline",
-  "examples/Backtest",
-  "examples/ConsoleApp",
-  "examples/*.sln",
   "GemFile",
   "node_modules",
   "vendor"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,7 +73,7 @@ pytest -svr A tests
 
 ### Performance benchmarking
 
-Running the commands below in your console will show performance data.  You can find the latest results [here]({{site.base_url}}/performance/).
+Running the commands below in your console will show performance data.  You can find the latest results [here]({{site.baseurl}}/performance/).
 
 ```bash
 # install pytest and other dependancies.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,23 +34,23 @@ We have different places to take issues by its category.
 
 If you are reporting a bug or suspect a problem, please submit an issue with a detailed description of the problem + include steps to reproduce, code samples, and any reference materials.  
 
-:wrench: [Report bugs]({{site.github.repository_url}}/issues)
+:wrench: [Report bugs](https://github.com/DaveSkender/Stock.Indicators.Python/issues)
 
 ### Feature Request
 
 For new features, submit an issue with the `enhancement` label.
 
-:bulb: [Request features]({{site.github.repository_url}}/issues)
+:bulb: [Request features](https://github.com/DaveSkender/Stock.Indicators.Python/issues)
 
 ## Project management
 
-- Planned work is managed in [the backlog]({{site.github.repository_url}}/projects/1).
+- Planned work is managed in [the backlog](https://github.com/DaveSkender/Stock.Indicators.Python/projects/1).
 - Work items are primarily [entered as Notes](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/adding-notes-to-a-project-board) (not Issues), except where an issue or feature is user reported.  With that said, Notes can be converted to Issues if in-progress and collaborative discussion is needed.
-- Use the [Discussions]({{site.github.base_repository_url}}/discussions) area for general ideation and unrelated questions.
+- Use the [Discussions](https://github.com/DaveSkender/Stock.Indicators/discussions) area for general ideation and unrelated questions.
 
 ## Developing
 
-- Read this first: [A Step by Step Guide to Making Your First GitHub Contribution](https://codeburst.io/a-step-by-step-guide-to-making-your-first-github-contribution-5302260a2940).  I also have a discussion [on Forking]({{site.github.base_repository_url}}/discussions/503) if you have questions.
+- Read this first: [A Step by Step Guide to Making Your First GitHub Contribution](https://codeburst.io/a-step-by-step-guide-to-making-your-first-github-contribution-5302260a2940).  I also have a discussion [on Forking](https://github.com/DaveSkender/Stock.Indicators/discussions/503) if you have questions.
 - If you are adding a new indicator, the easiest way to do this is to copy the folder of an existing indicator and rename everything using the same naming conventions and taxonomy.  All new indicators should include unit and performance tests.
 - Do not comingle multiple contributions.  Please keep changes small and separate.
 
@@ -73,7 +73,7 @@ pytest -svr A tests
 
 ### Performance benchmarking
 
-Running the commands below in your console will show performance data.  You can find the latest results [here]({{site.baseurl}}/performance/).
+Running the commands below in your console will show performance data.  You can find the latest results [here](https://daveskender.github.io/Stock.Indicators.Python/performance/).
 
 ```bash
 # install pytest and other dependancies.
@@ -129,7 +129,7 @@ We use the `GitVersion` tool for [semantic versioning](https://semver.org).  It 
 Type | Format | Description
 ------------ | ------ | -----------
 Major | `x.-.-` | A significant deviation with major breaking changes.
-Minor | `-.x.-` | A new feature, usually new non-breaking change, such as adding an indicator.  Minor breaking changes may occur here and are denoted in the [release notes]({{site.github.repository_url}}/releases).
+Minor | `-.x.-` | A new feature, usually new non-breaking change, such as adding an indicator.  Minor breaking changes may occur here and are denoted in the [release notes](https://github.com/DaveSkender/Stock.Indicators.Python/releases).
 Patch | `-.-.x` | A small bug fix, chore, or documentation change.
 Increment | `-.-.-+x` | Intermediate commits between releases.
 
@@ -139,7 +139,7 @@ This only needs to be done on the merge to `main` when the Pull Request is commi
 - Adding `+semver: minor` as a PR merge commit message will increment the minor -.x.- element
 - Adding `+semver: patch` as a PR merge commit message will increment the minor -.-.x element.  Patch element auto-increments, so you'd only need to do this to override the next value.
 
-A Git `tag`, in accordance with the above schema, is introduced automatically after deploying to PyPI and is reflected in the [Releases]({{site.github.repository_url}}/releases).
+A Git `tag`, in accordance with the above schema, is introduced automatically after deploying to PyPI and is reflected in the [Releases](https://github.com/DaveSkender/Stock.Indicators.Python/releases).
 
 ## License
 
@@ -149,7 +149,7 @@ This repository uses a standard Apache 2.0 open-source license.  It enables open
 
 ## Contact info
 
-[Start a new discussion, ask a question]({{site.github.base_repository_url}}/discussions), or [submit an issue]({{site.baseurl}}/contributing/#reporting-bugs-and-feature-requests) if it is publicly relevant.  You can also direct message [@daveskender](https://twitter.com/messages/compose?recipient_id=27475431).
+[Start a new discussion, ask a question](https://github.com/DaveSkender/Stock.Indicators/discussions), or [submit an issue](https://daveskender.github.io/Stock.Indicators.Python/contributing/#reporting-bugs-and-feature-requests) if it is publicly relevant.  You can also direct message [@daveskender](https://twitter.com/messages/compose?recipient_id=27475431).
 
 Thanks,
 Dave Skender

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -20,7 +20,7 @@ layout: default
 
 ### Installation and setup
 
-Find and install the **stock-indicators** Python package into your environment. See [more help](https://packaging.python.org/tutorials/installing-packages/) for installing packages.
+Find and install the **stock-indicators** Python package into your environment. See [more help](https://packaging.python.org/en/latest/tutorials/installing-packages/) for installing packages.
 
 ```powershell
 # pip example

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -36,22 +36,3 @@ Apple M1, 8 cores
 |           GetStoch |   4.212 ms |  0.044 ms |   4.198 ms |
 |        GetStochRsi |   4.984 ms |  0.120 ms |   4.939 ms |
 |      GetSuperTrend |   4.179 ms |  0.058 ms |   4.163 ms |
-
-<!-- ## quotes functions (mostly internal)
-
-|          Method |         Mean |      Error |     StdDev |
-|---------------- |-------------:|-----------:|-----------:|
-|            Sort | 37,768.62 ns | 406.995 ns | 360.790 ns |
-|        Validate | 40,457.78 ns | 301.177 ns | 266.985 ns |
-|       Aggregate |     83.36 ns |   0.699 ns |   0.545 ns |
-|  ConvertToBasic | 42,362.26 ns | 144.200 ns | 120.414 ns |
-| ConvertToQuotes |  8,378.83 ns |  71.755 ns |  63.609 ns |
-
-## math functions (internal)
-
-| Method | Periods |        Mean |    Error |   StdDev |
-|------- |-------- |------------:|---------:|---------:|
-| StdDev |      20 |    36.84 ns | 0.194 ns | 0.172 ns |
-| StdDev |      50 |    95.47 ns | 0.306 ns | 0.256 ns |
-| StdDev |     250 |   530.23 ns | 1.303 ns | 1.088 ns |
-| StdDev |    1000 | 2,142.94 ns | 5.994 ns | 5.313 ns | -->


### PR DESCRIPTION
### Description

- bad URL to performance page in the production site

Side note: I think since the contributor page is a core GitHub page too, we should avoid doing anything that only works in Jekyll site build.  Mostly, this just means hard-coding URLs instead of using `{{ }}` the placeholders.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
