### PR TITLE
fix: ADX image url

### DIFF
--- a/docs/_indicators/Adx.md
+++ b/docs/_indicators/Adx.md
@@ -70,7 +70,7 @@ results = indicators.get_adx(quotes, lookback_periods)
 Created by J. Welles Wilder, the [Average Directional Movement Index](https://en.wikipedia.org/wiki/Average_directional_movement_index) is a measure of price directional movement.  It includes upward and downward indicators, and is often used to measure strength of trend.
 [[Discuss] :speech_balloon:]({{site.github.base_repository_url}}/discussions/270 "Community discussion about this indicator")
 
-![image]({{site.charturl}}/Adx.png)
+![image]({{site.charturl}}/AdIndex.png)
 
 ### Sources
 


### PR DESCRIPTION
### Description

Renamed the source image for ADX since it was being blocked by Ad blockers due to its name.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
