### PR TITLE
chore: Add typing_extensions to install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setuptools.setup(
     python_requires=">=3.8",
     install_requires=[
         'pythonnet==2.5.2',
+        'typing_extensions>=4.0.0',
     ],
 )


### PR DESCRIPTION
### Description

 - Add typing_extensions to install_requires

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
