### PR TITLE
refactor: Rename type var to mark as private

### DIFF
--- a/stock_indicators/indicators/adl.py
+++ b/stock_indicators/indicators/adl.py
@@ -68,8 +68,8 @@ class ADLResult(ResultBase):
         self._csdata.AdlSma = value
 
 
-T = TypeVar("T", bound=ADLResult)
-class ADLResults(ToQuotesMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ADLResult)
+class ADLResults(ToQuotesMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of ADL(Accumulation/Distribution Line) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/adx.py
+++ b/stock_indicators/indicators/adx.py
@@ -61,8 +61,8 @@ class ADXResult(ResultBase):
         self._csdata.Adx = value
 
 
-T = TypeVar("T", bound=ADXResult)
-class ADXResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ADXResult)
+class ADXResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of ADX(Average Directional Movement Index) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/alligator.py
+++ b/stock_indicators/indicators/alligator.py
@@ -62,8 +62,8 @@ class AlligatorResult(ResultBase):
         self._csdata.Lips = CsDecimal(value)
 
 
-T = TypeVar("T", bound=AlligatorResult)
-class AlligatorResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=AlligatorResult)
+class AlligatorResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Williams Alligator results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/alma.py
+++ b/stock_indicators/indicators/alma.py
@@ -54,8 +54,8 @@ class ALMAResult(ResultBase):
         self._csdata.Alma = CsDecimal(value)
 
 
-T = TypeVar("T", bound=ALMAResult)
-class ALMAResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ALMAResult)
+class ALMAResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of ALMA(Arnaud Legoux Moving Average) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/aroon.py
+++ b/stock_indicators/indicators/aroon.py
@@ -63,8 +63,8 @@ class AroonResult(ResultBase):
         self._csdata.Oscillator = CsDecimal(value)
 
 
-T = TypeVar("T", bound=AroonResult)
-class AroonResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=AroonResult)
+class AroonResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Aroon results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/atr.py
+++ b/stock_indicators/indicators/atr.py
@@ -63,8 +63,8 @@ class ATRResult(ResultBase):
         self._csdata.Atrp = CsDecimal(value)
 
 
-T = TypeVar("T", bound=ATRResult)
-class ATRResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ATRResult)
+class ATRResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of ATR(Average True Range) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/awesome.py
+++ b/stock_indicators/indicators/awesome.py
@@ -56,8 +56,8 @@ class AwesomeResult(ResultBase):
         self._csdata.Normalized = value
 
 
-T = TypeVar("T", bound=AwesomeResult)
-class AwesomeResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=AwesomeResult)
+class AwesomeResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Awesome Oscillator (aka Super AO) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/beta.py
+++ b/stock_indicators/indicators/beta.py
@@ -47,8 +47,8 @@ class BetaResult(ResultBase):
         self._csdata.Beta = value
 
 
-T = TypeVar("T", bound=BetaResult)
-class BetaResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=BetaResult)
+class BetaResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Beta results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/bollinger_bands.py
+++ b/stock_indicators/indicators/bollinger_bands.py
@@ -91,8 +91,8 @@ class BollingerBandsResult(ResultBase):
         self._csdata.Width = value
 
 
-T = TypeVar("T", bound=BollingerBandsResult)
-class BollingerBandsResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=BollingerBandsResult)
+class BollingerBandsResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Bollinger Bands results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/bop.py
+++ b/stock_indicators/indicators/bop.py
@@ -46,8 +46,8 @@ class BOPResult(ResultBase):
         self._csdata.Bop = value
 
 
-T = TypeVar("T", bound=BOPResult)
-class BOPResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=BOPResult)
+class BOPResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Balance of Power (aka Balance of Market Power) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/cci.py
+++ b/stock_indicators/indicators/cci.py
@@ -45,8 +45,8 @@ class CCIResult(ResultBase):
         self._csdata.Cci = value
 
 
-T = TypeVar("T", bound=CCIResult)
-class CCIResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=CCIResult)
+class CCIResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Commodity Channel Index (CCI) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/chaikin_oscillator.py
+++ b/stock_indicators/indicators/chaikin_oscillator.py
@@ -72,8 +72,8 @@ class ChaikinOscResult(ResultBase):
         self._csdata.Oscillator = value
 
 
-T = TypeVar("T", bound=ChaikinOscResult)
-class ChaikinOscResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ChaikinOscResult)
+class ChaikinOscResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Chaikin Oscillator results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/chandelier.py
+++ b/stock_indicators/indicators/chandelier.py
@@ -51,8 +51,8 @@ class ChandelierResult(ResultBase):
         self._csdata.ChandelierExit = CsDecimal(value)
 
 
-T = TypeVar("T", bound=ChandelierResult)
-class ChandelierResults(RemoveWarmupMixin,IndicatorResults[T]):
+_T = TypeVar("_T", bound=ChandelierResult)
+class ChandelierResults(RemoveWarmupMixin,IndicatorResults[_T]):
     """
     A wrapper class for the list of Chandelier Exit results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/chop.py
+++ b/stock_indicators/indicators/chop.py
@@ -48,8 +48,8 @@ class ChopResult(ResultBase):
         self._csdata.Chop = CsDecimal(value)
 
 
-T = TypeVar("T", bound=ChopResult)
-class ChopResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ChopResult)
+class ChopResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Choppiness Index (CHOP) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/cmf.py
+++ b/stock_indicators/indicators/cmf.py
@@ -61,8 +61,8 @@ class CMFResult(ResultBase):
         self._csdata.Cmf = value
 
 
-T = TypeVar("T", bound=CMFResult)
-class CMFResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=CMFResult)
+class CMFResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Chaikin Money Flow (CMF) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/common/results.py
+++ b/stock_indicators/indicators/common/results.py
@@ -21,13 +21,13 @@ class ResultBase:
     def date(self, value):
         self._csdata.Date = CsDateTime(value)
 
-T = TypeVar("T", bound=ResultBase)
-class IndicatorResults(List[T]):
+_T = TypeVar("_T", bound=ResultBase)
+class IndicatorResults(List[_T]):
     """
     A base wrapper class for the list of results.
     It provides helper methods written in CSharp implementation.
     """
-    def __init__(self, data: Iterable, wrapper_class: Type[T]):
+    def __init__(self, data: Iterable, wrapper_class: Type[_T]):
         super().__init__([ wrapper_class(_) for _ in data ])
         self._csdata = data
         self._wrapper_class = wrapper_class
@@ -75,7 +75,7 @@ class IndicatorResults(List[T]):
         return self.__class__(self._csdata.__mul__(other._csdata), self._wrapper_class)
 
     @_verify_data
-    def find(self, lookup_date: PyDateTime) -> T:
+    def find(self, lookup_date: PyDateTime) -> _T:
         if not isinstance(lookup_date, PyDateTime):
             raise TypeError(
                 "lookup_date must be an instance of datetime.datetime."

--- a/stock_indicators/indicators/connors_rsi.py
+++ b/stock_indicators/indicators/connors_rsi.py
@@ -77,8 +77,8 @@ class ConnorsRSIResult(ResultBase):
         self._csdata.ConnorsRsi = value
 
 
-T = TypeVar("T", bound=ConnorsRSIResult)
-class ConnorsRSIResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ConnorsRSIResult)
+class ConnorsRSIResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Connors RSI results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/correlation.py
+++ b/stock_indicators/indicators/correlation.py
@@ -81,8 +81,8 @@ class CorrelationResult(ResultBase):
         self._csdata.RSquared = value
 
 
-T = TypeVar("T", bound=CorrelationResult)
-class CorrelationResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=CorrelationResult)
+class CorrelationResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Correlation Coefficient results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/donchian.py
+++ b/stock_indicators/indicators/donchian.py
@@ -71,8 +71,8 @@ class DonchianResult(ResultBase):
         self._csdata.Width = CsDecimal(value)
 
 
-T = TypeVar("T", bound=DonchianResult)
-class DonchianResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=DonchianResult)
+class DonchianResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Donchian Channels results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/double_ema.py
+++ b/stock_indicators/indicators/double_ema.py
@@ -47,8 +47,8 @@ class DEMAResult(ResultBase):
         self._csdata.Dema = CsDecimal(value)
 
 
-T = TypeVar("T", bound=DEMAResult)
-class DEMAResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=DEMAResult)
+class DEMAResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Double Exponential Moving Average (DEMA) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/dpo.py
+++ b/stock_indicators/indicators/dpo.py
@@ -56,8 +56,8 @@ class DPOResult(ResultBase):
         self._csdata.Dpo = CsDecimal(value)
 
 
-T = TypeVar("T", bound=DPOResult)
-class DPOResults(ToQuotesMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=DPOResult)
+class DPOResults(ToQuotesMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Detrended Price Oscillator (DPO) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/elder_ray.py
+++ b/stock_indicators/indicators/elder_ray.py
@@ -63,8 +63,8 @@ class ElderRayResult(ResultBase):
         self._csdata.BearPower = CsDecimal(value)
 
 
-T = TypeVar("T", bound=ElderRayResult)
-class ElderRayResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ElderRayResult)
+class ElderRayResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Elder-ray Index results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/ema.py
+++ b/stock_indicators/indicators/ema.py
@@ -47,8 +47,8 @@ class EMAResult(ResultBase):
         self._csdata.Ema = CsDecimal(value)
 
 
-T = TypeVar("T", bound=EMAResult)
-class EMAResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=EMAResult)
+class EMAResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of EMA(Exponential Moving Average) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/epma.py
+++ b/stock_indicators/indicators/epma.py
@@ -49,8 +49,8 @@ class EPMAResult(ResultBase):
         self._csdata.Epma = CsDecimal(value)
 
 
-T = TypeVar("T", bound=EPMAResult)
-class EPMAResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=EPMAResult)
+class EPMAResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Endpoint Moving Average (EPMA) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/fcb.py
+++ b/stock_indicators/indicators/fcb.py
@@ -57,8 +57,8 @@ class FCBResult(ResultBase):
         self._csdata.LowerBand = CsDecimal(value)
 
 
-T = TypeVar("T", bound=FCBResult)
-class FCBResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=FCBResult)
+class FCBResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Fractal Chaos Bands (FCB) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/fractal.py
+++ b/stock_indicators/indicators/fractal.py
@@ -63,8 +63,8 @@ class FractalResult(ResultBase):
         self._csdata.FractalBull = CsDecimal(value)
 
 
-T = TypeVar("T", bound=FractalResult)
-class FractalResults(IndicatorResults[T]):
+_T = TypeVar("_T", bound=FractalResult)
+class FractalResults(IndicatorResults[_T]):
     """
     A wrapper class for the list of Williams Fractal results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/heikin_ashi.py
+++ b/stock_indicators/indicators/heikin_ashi.py
@@ -76,8 +76,8 @@ class HeikinAshiResult(ResultBase):
         self._csdata.Volume = CsDecimal(value)
 
 
-T = TypeVar("T", bound=HeikinAshiResult)
-class HeikinAshiResults(ToQuotesMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=HeikinAshiResult)
+class HeikinAshiResults(ToQuotesMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Heikin-Ashi results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/ichimoku.py
+++ b/stock_indicators/indicators/ichimoku.py
@@ -90,8 +90,8 @@ class IchimokuResult(ResultBase):
         self._csdata.ChikouSpan = CsDecimal(value)
 
 
-T = TypeVar("T", bound=IchimokuResult)
-class IchimokuResults(IndicatorResults[T]):
+_T = TypeVar("_T", bound=IchimokuResult)
+class IchimokuResults(IndicatorResults[_T]):
     """
     A wrapper class for the list of Ichimoku Cloud results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/macd.py
+++ b/stock_indicators/indicators/macd.py
@@ -86,8 +86,8 @@ class MACDResult(ResultBase):
         self._csdata.SlowEma = CsDecimal(value)
 
 
-T = TypeVar("T", bound=MACDResult)
-class MACDResults(RemoveWarmupMixin ,IndicatorResults[T]):
+_T = TypeVar("_T", bound=MACDResult)
+class MACDResults(RemoveWarmupMixin ,IndicatorResults[_T]):
     """
     A wrapper class for the list of MACD(Moving Average Convergence/Divergence) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/parabolic_sar.py
+++ b/stock_indicators/indicators/parabolic_sar.py
@@ -78,8 +78,8 @@ class ParabolicSARResult(ResultBase):
         self._csdata.IsReversal = value
 
 
-T = TypeVar("T", bound=ParabolicSARResult)
-class ParabolicSARResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ParabolicSARResult)
+class ParabolicSARResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Parabolic SAR(stop and reverse) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/roc.py
+++ b/stock_indicators/indicators/roc.py
@@ -86,8 +86,8 @@ class ROCResult(ResultBase):
         self._csdata.RocSma = value
 
 
-T = TypeVar("T", bound=ROCResult)
-class ROCResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ROCResult)
+class ROCResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of ROC(Rate of Change) results.
     It is exactly same with built-in `list` except for that it provides
@@ -133,8 +133,8 @@ class ROCWBResult(ResultBase):
         self._csdata.LowerBand = value
 
 
-T = TypeVar("T", bound=ROCWBResult)
-class ROCWBResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=ROCWBResult)
+class ROCWBResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of ROC(Rate of Change) with band results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/rsi.py
+++ b/stock_indicators/indicators/rsi.py
@@ -45,8 +45,8 @@ class RSIResult(ResultBase):
         self._csdata.Rsi = value
 
 
-T = TypeVar("T", bound=RSIResult)
-class RSIResults(ToQuotesMixin, RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=RSIResult)
+class RSIResults(ToQuotesMixin, RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of RSI(Relative Strength Index) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/slope.py
+++ b/stock_indicators/indicators/slope.py
@@ -79,8 +79,8 @@ class SlopeResult(ResultBase):
     def line(self, value):
         self._csdata.Line = CsDecimal(value)
 
-T = TypeVar("T", bound=SlopeResult)
-class SlopeResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=SlopeResult)
+class SlopeResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Slope results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/sma.py
+++ b/stock_indicators/indicators/sma.py
@@ -72,8 +72,8 @@ class SMAResult(ResultBase):
         self._csdata.Sma = CsDecimal(value)
 
 
-T = TypeVar("T", bound=SMAResult)
-class SMAResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=SMAResult)
+class SMAResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of SMA(Simple Moving Average) results.
     It is exactly same with built-in `list` except for that it provides
@@ -111,8 +111,8 @@ class SMAExtendedResult(SMAResult):
         self._csdata.Mape = value
 
 
-T = TypeVar("T", bound=SMAExtendedResult)
-class SMAExtendedResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=SMAExtendedResult)
+class SMAExtendedResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of SMA-Extended results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/stdev_channels.py
+++ b/stock_indicators/indicators/stdev_channels.py
@@ -77,8 +77,8 @@ class StdevChannelsResult(ResultBase):
         self._csdata.BreakPoint = value
 
 
-T = TypeVar("T", bound=StdevChannelsResult)
-class StdevChannelsResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=StdevChannelsResult)
+class StdevChannelsResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Standard Deviation Channels results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/stoch.py
+++ b/stock_indicators/indicators/stoch.py
@@ -75,8 +75,8 @@ class StochResult(ResultBase):
     j = percent_j
 
 
-T = TypeVar("T", bound=StochResult)
-class StochResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=StochResult)
+class StochResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Stochastic Oscillator(with KDJ Index) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/stoch_rsi.py
+++ b/stock_indicators/indicators/stoch_rsi.py
@@ -64,8 +64,8 @@ class StochRSIResult(ResultBase):
         self._csdata.Signal = CsDecimal(value)
 
 
-T = TypeVar("T", bound=StochRSIResult)
-class StochRSIResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=StochRSIResult)
+class StochRSIResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Stochastic RSI results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/super_trend.py
+++ b/stock_indicators/indicators/super_trend.py
@@ -68,8 +68,8 @@ class SuperTrendResult(ResultBase):
         self._csdata.LowerBand = CsDecimal(value)
 
 
-T = TypeVar("T", bound=SuperTrendResult)
-class SuperTrendResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=SuperTrendResult)
+class SuperTrendResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Super Trend results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/triple_ema.py
+++ b/stock_indicators/indicators/triple_ema.py
@@ -48,8 +48,8 @@ class TEMAResult(ResultBase):
         self._csdata.Tema = CsDecimal(value)
 
 
-T = TypeVar("T", bound=TEMAResult)
-class TEMAResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=TEMAResult)
+class TEMAResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Triple Exponential Moving Average (TEMA) results.
     It is exactly same with built-in `list` except for that it provides

--- a/stock_indicators/indicators/trix.py
+++ b/stock_indicators/indicators/trix.py
@@ -67,8 +67,8 @@ class TRIXResult(ResultBase):
         self._csdata.Signal = CsDecimal(value)
 
 
-T = TypeVar("T", bound=TRIXResult)
-class TRIXResults(RemoveWarmupMixin, IndicatorResults[T]):
+_T = TypeVar("_T", bound=TRIXResult)
+class TRIXResults(RemoveWarmupMixin, IndicatorResults[_T]):
     """
     A wrapper class for the list of Triple EMA Oscillator (TRIX) results.
     It is exactly same with built-in `list` except for that it provides


### PR DESCRIPTION
### Description

 - Rename type var to mark as private.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
