### PR TITLE
chore: Bump pythonnet from 2.5.2 to 3.0.0a1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # _cslib
-pythonnet==2.5.2
+pythonnet==3.0.0a1
 typing_extensions>=4.0.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        'pythonnet==2.5.2',
+        'pythonnet==3.0.0a1',
         'typing_extensions>=4.0.0',
     ],
 )

--- a/stock_indicators/indicators/common/results.py
+++ b/stock_indicators/indicators/common/results.py
@@ -31,7 +31,7 @@ class IndicatorResults(List[_T]):
     """
     def __init__(self, data: Iterable, wrapper_class: Type[_T]):
         super().__init__([ wrapper_class(_) for _ in data ])
-        self._csdata = data
+        self._csdata = list(data)
         self._wrapper_class = wrapper_class
 
     def reload(self):
@@ -40,7 +40,7 @@ class IndicatorResults(List[_T]):
         It is usually called after `done()`
         """
         if self._csdata is None:
-            self._csdata: Iterable = [ _._csdata for _ in self ]
+            self._csdata = [ _._csdata for _ in self ]
         return self
 
     def done(self):

--- a/tests/test_doji.py
+++ b/tests/test_doji.py
@@ -11,7 +11,7 @@ class TestDoji:
         
         r = results[1]
         assert r.price is None
-        assert r.signal == 0
+        assert Signal.NONE == r.signal
         
         r = results[23]
         assert 216.28 == round(float(r.price), 2)
@@ -31,7 +31,7 @@ class TestDoji:
         
         r = results[451]
         assert 273.64 == round(float(r.price), 2)
-        assert 1 == r.signal
+        assert Signal.NEUTRAL == r.signal
         
         r = results[477]
         assert 256.86 == round(float(r.price), 2)

--- a/tests/test_marubozu.py
+++ b/tests/test_marubozu.py
@@ -11,7 +11,7 @@ class TestMarubozu:
         
         r = results[31]
         assert r.price is None
-        assert r.signal == 0
+        assert r.signal == Signal.NONE
         
         r = results[32]
         assert 222.10 == round(float(r.price), 2)


### PR DESCRIPTION
### Description

 - Bump pythonnet from 2.5.2 to 3.0.0a1 .

Fixes #13 , Fixes #58 

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
