### PR TITLE
refactor: Make shortcut for `Quote` class

### DIFF
--- a/stock_indicators/__init__.py
+++ b/stock_indicators/__init__.py
@@ -13,3 +13,5 @@ and others. We had private trading algorithms, machine learning,
 and charting systems in mind when originally creating this community
 library. A Stock Indicators for .NET is also available.
 """
+
+from stock_indicators.indicators.common.quote import Quote


### PR DESCRIPTION
### Description

 - Make shortcut for `Quote` class.
 - It enables `from stock_indicators import Quote`, not only `from stock_indicators.indicators.common.quotes import Quote`

### Checklist

- [ ] My code follows the existing style, code structure, and naming taxonomy
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my own code and included any verifying manual calculations
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [ ] My changes generate no new warnings and running code analysis does not produce any issues
- [ ] I have added or run the performance tests that depict optimal execution times
- [ ] I have made corresponding changes to the documentation
