### PR TITLE
feat: Make inheritance relationship compatible with C#

### DIFF
--- a/stock_indicators/_cslib/__init__.py
+++ b/stock_indicators/_cslib/__init__.py
@@ -28,6 +28,7 @@ from System.Collections.Generic import List as CsList
 # Classes
 from Skender.Stock.Indicators import Indicator as CsIndicator
 from Skender.Stock.Indicators import Quote as CsQuote
+from Skender.Stock.Indicators import CandleProperties as CsCandleProperties
 from Skender.Stock.Indicators import ResultBase as CsResultBase
 
 # Enums

--- a/stock_indicators/indicators/common/_contrib/type_resolver.py
+++ b/stock_indicators/indicators/common/_contrib/type_resolver.py
@@ -1,0 +1,5 @@
+from typing import Type, TypeVar, cast
+
+_T = TypeVar("_T")
+def _generate_cs_inherited_class(child: Type[_T], cs_parent: Type):
+    return cast(Type[_T] , type("_Wrapper", (cs_parent, ), dict(child.__dict__)))

--- a/stock_indicators/indicators/common/_contrib/type_resolver.py
+++ b/stock_indicators/indicators/common/_contrib/type_resolver.py
@@ -1,5 +1,5 @@
 from typing import Type, TypeVar, cast
 
 _T = TypeVar("_T")
-def _generate_cs_inherited_class(child: Type[_T], cs_parent: Type):
+def generate_cs_inherited_class(child: Type[_T], cs_parent: Type):
     return cast(Type[_T] , type("_Wrapper", (cs_parent, ), dict(child.__dict__)))

--- a/stock_indicators/indicators/common/candles.py
+++ b/stock_indicators/indicators/common/candles.py
@@ -3,10 +3,12 @@ from typing import Optional, TypeVar
 
 from typing_extensions import Self
 
+from stock_indicators._cslib import CsCandleProperties
 from stock_indicators._cstypes import Decimal as CsDecimal
 from stock_indicators._cstypes import to_pydecimal
+from stock_indicators.indicators.common._contrib.type_resolver import _generate_cs_inherited_class
 from stock_indicators.indicators.common.enums import Signal
-from stock_indicators.indicators.common.quote import Quote
+from stock_indicators.indicators.common.quote import _Quote
 from stock_indicators.indicators.common.results import IndicatorResults, ResultBase
 
 
@@ -20,7 +22,7 @@ class CondenseMixin:
         return self.__class__(filter(lambda x: x.signal != Signal.NONE, self), self._wrapper_class)
 
 
-class CandleProperties(Quote):
+class _CandleProperties(_Quote):
     """
     A wrapper class for `CsCandleProperties`, which is an extended version of `Quote`.
     It contains additional calculated properties.
@@ -67,6 +69,9 @@ class CandleProperties(Quote):
     @property
     def is_bearish(self) -> bool:
         return self.Close < self.Open
+
+
+CandleProperties = _generate_cs_inherited_class(_CandleProperties, CsCandleProperties)
 
 
 class CandleResult(ResultBase):

--- a/stock_indicators/indicators/common/candles.py
+++ b/stock_indicators/indicators/common/candles.py
@@ -6,7 +6,7 @@ from typing_extensions import Self
 from stock_indicators._cslib import CsCandleProperties
 from stock_indicators._cstypes import Decimal as CsDecimal
 from stock_indicators._cstypes import to_pydecimal
-from stock_indicators.indicators.common._contrib.type_resolver import _generate_cs_inherited_class
+from stock_indicators.indicators.common._contrib.type_resolver import generate_cs_inherited_class
 from stock_indicators.indicators.common.enums import Signal
 from stock_indicators.indicators.common.quote import _Quote
 from stock_indicators.indicators.common.results import IndicatorResults, ResultBase
@@ -71,7 +71,7 @@ class _CandleProperties(_Quote):
         return self.Close < self.Open
 
 
-CandleProperties = _generate_cs_inherited_class(_CandleProperties, CsCandleProperties)
+CandleProperties = generate_cs_inherited_class(_CandleProperties, CsCandleProperties)
 
 
 class CandleResult(ResultBase):

--- a/stock_indicators/indicators/common/quote.py
+++ b/stock_indicators/indicators/common/quote.py
@@ -1,8 +1,11 @@
+from decimal import Decimal
+
 from stock_indicators._cslib import CsQuote
 from stock_indicators._cstypes import DateTime as CsDateTime
 from stock_indicators._cstypes import Decimal as CsDecimal
 from stock_indicators._cstypes.datetime import to_pydatetime
 from stock_indicators._cstypes.decimal import to_pydecimal
+from stock_indicators.indicators.common._contrib.type_resolver import _generate_cs_inherited_class
 
 
 def _get_date(quote):
@@ -41,7 +44,7 @@ def _get_volume(quote):
 def _set_volume(quote, value):
     quote.Volume = CsDecimal(value)
 
-class Quote(CsQuote):
+class _Quote:
     """
     A base wrapper class for a single unit of historical quotes.
     """
@@ -55,11 +58,11 @@ class Quote(CsQuote):
 
     def __init__(self, date, open = None, high = None, low = None, close = None, volume = None):
         self.date = date
-        self.open = open if open else super().Open
-        self.high = high if high else super().High
-        self.low = low if low else super().Low
-        self.close = close if close else super().Close
-        self.volume = volume if volume else super().Volume
+        self.open: Decimal = open if open else 0
+        self.high: Decimal = high if high else 0
+        self.low: Decimal = low if low else 0
+        self.close: Decimal = close if close else 0
+        self.volume: Decimal = volume if volume else 0
 
     @classmethod
     def from_csquote(cls, csQuote: CsQuote):
@@ -75,3 +78,5 @@ class Quote(CsQuote):
             close=csQuote.Close,
             volume=csQuote.Volume
         )
+
+Quote = _generate_cs_inherited_class(_Quote, CsQuote)

--- a/stock_indicators/indicators/common/quote.py
+++ b/stock_indicators/indicators/common/quote.py
@@ -5,7 +5,7 @@ from stock_indicators._cstypes import DateTime as CsDateTime
 from stock_indicators._cstypes import Decimal as CsDecimal
 from stock_indicators._cstypes.datetime import to_pydatetime
 from stock_indicators._cstypes.decimal import to_pydecimal
-from stock_indicators.indicators.common._contrib.type_resolver import _generate_cs_inherited_class
+from stock_indicators.indicators.common._contrib.type_resolver import generate_cs_inherited_class
 
 
 def _get_date(quote):
@@ -79,4 +79,4 @@ class _Quote:
             volume=csQuote.Volume
         )
 
-Quote = _generate_cs_inherited_class(_Quote, CsQuote)
+Quote = generate_cs_inherited_class(_Quote, CsQuote)

--- a/tests/common/test_type_compatibility.py
+++ b/tests/common/test_type_compatibility.py
@@ -1,0 +1,14 @@
+
+from stock_indicators._cslib import CsQuote, CsCandleProperties
+from stock_indicators.indicators.common.candles import CandleProperties
+from stock_indicators.indicators.common.quote import Quote
+
+class TestTypeCompat:
+    def test_quote_based_class(self):
+        # Quote
+        assert issubclass(Quote, CsQuote)
+        
+        # CandleProperties
+        assert issubclass(CandleProperties, Quote)
+        assert issubclass(CandleProperties, CsQuote)
+        assert issubclass(CandleProperties, CsCandleProperties)


### PR DESCRIPTION
### Description

 - Make inheritance relationship compatible with C#
   - CLR does not allow multiple inheritance.
   - Wrapper classes are re-assembled when they are inherited.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
