### PR TITLE
chore: Update setup.py for manual build

### DIFF
--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -64,8 +64,11 @@ jobs:
           configFilePath: 'gitversion.yml'
       
       - powershell: |
-          echo "Current version: $(GitVersion.SemVer)"
-        displayName: Shows GitVersion
+          echo "Current SemVer: $(GitVersion.SemVer)"
+          echo "Current MajorMinorPatch: $(GitVersion.MajorMinorPatch)"
+          sed -i "s/version=.*/version=\'$(GitVersion.MajorMinorPatch)\',/g" setup.py
+          cat setup.py
+        displayName: Update version string in setup.py
 
       - script: |
           python -m pip install --upgrade pip setuptools wheel build
@@ -74,7 +77,7 @@ jobs:
       - task: CmdLine@2
         displayName: "Build"
         inputs:
-          script: "python setup.py $(GitVersion.SemVer) sdist bdist_wheel"
+          script: "python setup.py sdist bdist_wheel"
           workingDirectory: $(Build.SourcesDirectory)
         #condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -64,11 +64,8 @@ jobs:
           configFilePath: 'gitversion.yml'
       
       - powershell: |
-          echo "Current SemVer: $(GitVersion.SemVer)"
-          echo "Current MajorMinorPatch: $(GitVersion.MajorMinorPatch)"
-          sed -i "s/version=.*/version=\'$(GitVersion.MajorMinorPatch)\',/g" setup.py
-          cat setup.py
-        displayName: Update version string in setup.py
+          echo "Current version: $(GitVersion.SemVer)"
+        displayName: Shows GitVersion
 
       - script: |
           python -m pip install --upgrade pip setuptools wheel build
@@ -77,7 +74,7 @@ jobs:
       - task: CmdLine@2
         displayName: "Build"
         inputs:
-          script: "python setup.py sdist bdist_wheel"
+          script: "python setup.py sdist bdist_wheel semver:$(GitVersion.SemVer)"
           workingDirectory: $(Build.SourcesDirectory)
         #condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,24 @@
+import sys
 import setuptools
 
+# Set semver.
+PREFIX_VERSION = "semver:"
+DEFAULT_VERSION = "0.0.0.dev0"
+
+if sys.argv[-1].startswith(PREFIX_VERSION):
+    version = sys.argv[-1].split(':')[1]
+    sys.argv.pop()
+else:
+    version = DEFAULT_VERSION
+
+
+# Build.
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="stock-indicators",
-    version="0.7.0",
+    version=version,
     author="Dave Skender",
     maintainer="Dong-Geon Lee",
     description="Stock Indicators for Python.  Send in historical price quotes and get back desired technical indicators such as Stochastic RSI, Average True Range, Parabolic SAR, etc.  Nothing more.",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-import sys
-version = sys.argv[1]
-del sys.argv[1]
 import setuptools
 
 with open("README.md", "r", encoding="utf-8") as fh:
@@ -8,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="stock-indicators",
-    version=version,
+    version="0.7.0",
     author="Dave Skender",
     maintainer="Dong-Geon Lee",
     description="Stock Indicators for Python.  Send in historical price quotes and get back desired technical indicators such as Stochastic RSI, Average True Range, Parabolic SAR, etc.  Nothing more.",


### PR DESCRIPTION
### Description

 - Don't let setup.py receive its semver from CLI argument.
 - Replace semver in setup.py using `sed`.

prevents #197. 

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
