### PR TITLE
fix: Fix ZigZag `point_type` to be Optional str

### DIFF
--- a/stock_indicators/indicators/zig_zag.py
+++ b/stock_indicators/indicators/zig_zag.py
@@ -54,7 +54,7 @@ class ZigZagResult(ResultBase):
         self._csdata.ZigZag = CsDecimal(value)
 
     @property
-    def point_type(self) -> str:
+    def point_type(self) -> Optional[str]:
         return self._csdata.PointType
 
     @point_type.setter


### PR DESCRIPTION
### Description

 - Fix ZigZag `point_type` to be Optional str

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
