### PR TITLE
fix: Fix magic methods for built-in list

### DIFF
--- a/stock_indicators/indicators/common/results.py
+++ b/stock_indicators/indicators/common/results.py
@@ -21,6 +21,7 @@ class ResultBase:
     def date(self, value):
         self._csdata.Date = CsDateTime(value)
 
+
 _T = TypeVar("_T", bound=ResultBase)
 class IndicatorResults(List[_T]):
     """
@@ -70,11 +71,11 @@ class IndicatorResults(List[_T]):
 
     @_verify_data
     def __add__(self, other: "IndicatorResults"):
-        return self.__class__(self._csdata.__add__(other._csdata), self._wrapper_class)
+        return self.__class__(list(self._csdata).__add__(list(other._csdata)), self._wrapper_class)
 
     @_verify_data
-    def __mul__(self, other: "IndicatorResults"):
-        return self.__class__(self._csdata.__mul__(other._csdata), self._wrapper_class)
+    def __mul__(self, value: int):
+        return self.__class__(list(self._csdata).__mul__(value), self._wrapper_class)
 
     @_verify_data
     def find(self, lookup_date: PyDateTime) -> _T:

--- a/tests/common/test_indicator_results.py
+++ b/tests/common/test_indicator_results.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+
+import pytest
+from stock_indicators import indicators
+
+class TestIndicatorResults:
+    def test_add_results(self, quotes):
+        results = indicators.get_sma(quotes, 20)
+        r4 = results + results + results + results
+        
+        assert len(r4) == len(results) * 4
+        
+        for i in range(4):
+            idx = len(results)*i
+            assert r4[18+idx].sma is None
+            assert 214.5250 == round(float(r4[19+idx].sma), 4)
+            assert 215.0310 == round(float(r4[24+idx].sma), 4)
+            assert 234.9350 == round(float(r4[149+idx].sma), 4)
+            assert 255.5500 == round(float(r4[249+idx].sma), 4)
+            assert 251.8600 == round(float(r4[501+idx].sma), 4)
+    
+    def test_mul_results(self, quotes):
+        results = indicators.get_sma(quotes, 20)
+        r4 = results * 4
+        
+        assert len(r4) == len(results) * 4
+
+        for i in range(4):
+            idx = len(results)*i
+            assert r4[18+idx].sma is None
+            assert 214.5250 == round(float(r4[19+idx].sma), 4)
+            assert 215.0310 == round(float(r4[24+idx].sma), 4)
+            assert 234.9350 == round(float(r4[149+idx].sma), 4)
+            assert 255.5500 == round(float(r4[249+idx].sma), 4)
+            assert 251.8600 == round(float(r4[501+idx].sma), 4)
+            
+    def test_done_and_reload(self, quotes):
+        results = indicators.get_sma(quotes, 20)
+        results.done()
+        
+        with pytest.raises(ValueError):
+            results * 2
+
+        results.reload()
+        r2 = results * 2
+        
+        assert len(r2) == len(results) * 2
+        
+    def test_find(self, quotes):
+        results = indicators.get_sma(quotes, 20)
+        
+        # r[18]
+        r = results.find(datetime(2017, 1, 30))
+        assert r.sma is None
+
+    def test_remove_with_period(self, quotes):
+        results = indicators.get_sma(quotes, 20)
+        length = len(results)
+        
+        results = results.remove_warmup_periods(50)
+        assert len(results) == length - 50


### PR DESCRIPTION
### Description

 - Fix magic methods for built-in list
   - `__add__`, `__mul__`
 - Add tests for `IndicatorResults` methods 

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
