### PR TITLE
feat: Drop Mono support

### DIFF
--- a/stock_indicators/_cslib/__init__.py
+++ b/stock_indicators/_cslib/__init__.py
@@ -14,19 +14,15 @@ try:
     from pythonnet import load
     load(runtime="coreclr",
         runtime_config=os.path.join(os.path.dirname(__file__), 'runtimeconfig.json'))
+    import clr
 
-finally:
-    try:
-        import clr
+except Exception as e:
+    raise ImportError(("fail to import clr.\n"
+    "Stock Indicators for Python has dependency on pythonnet, which uses CLR.\n"
+    "Check that you have CLR installed. It's currently using .NET6.\n"
+    ".NET:\n\t"
+    "https://dotnet.microsoft.com/en-us/download/dotnet")) from e
 
-    except:
-        raise ImportError(("fail to import clr.\n"
-        "Stock Indicators for Python has dependency on pythonnet, which uses CLR.\n"
-        "Check that you have CLR installed, such as .NET6.0+ or Mono.\n"
-        ".NET:\n\t"
-        "https://dotnet.microsoft.com/en-us/download/dotnet\n"
-        "Mono:\n\t"
-        "https://www.mono-project.com/download/stable/"))
 
 skender_stock_indicators_dll_path = os.path.join(
     os.path.dirname(__file__),


### PR DESCRIPTION
### Description

 - Drop mono support
 - Looks like Mono does not fully support .NET6

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
