### PR TITLE
fix: Fix wrapping CandleProperties

### DIFF
--- a/stock_indicators/indicators/common/_contrib/type_resolver.py
+++ b/stock_indicators/indicators/common/_contrib/type_resolver.py
@@ -1,5 +1,5 @@
 from typing import Type, TypeVar, cast
 
 _T = TypeVar("_T")
-def generate_cs_inherited_class(child: Type[_T], cs_parent: Type):
-    return cast(Type[_T] , type("_Wrapper", (cs_parent, ), dict(child.__dict__)))
+def generate_cs_inherited_class(child: Type[_T], cs_parent: Type, class_name="_Wrapper"):
+    return cast(Type[_T], type(class_name, (cs_parent, ), {attr: getattr(child, attr) for attr in  dir(child)}))

--- a/stock_indicators/indicators/common/candles.py
+++ b/stock_indicators/indicators/common/candles.py
@@ -71,7 +71,7 @@ class _CandleProperties(_Quote):
         return self.Close < self.Open
 
 
-CandleProperties = generate_cs_inherited_class(_CandleProperties, CsCandleProperties)
+CandleProperties = generate_cs_inherited_class(_CandleProperties, CsCandleProperties, "CandleProperties")
 
 
 class CandleResult(ResultBase):

--- a/stock_indicators/indicators/common/quote.py
+++ b/stock_indicators/indicators/common/quote.py
@@ -92,4 +92,4 @@ class _Quote:
         return CsQuoteUtility.Use[Quote](CsList(Quote, quotes), candle_part.cs_value)
 
 
-Quote = generate_cs_inherited_class(_Quote, CsQuote)
+Quote = generate_cs_inherited_class(_Quote, CsQuote, "Quote")

--- a/tests/common/test_candle.py
+++ b/tests/common/test_candle.py
@@ -1,0 +1,41 @@
+from stock_indicators import indicators
+
+class TestCandleResults:
+    def test_standard(self, quotes):
+        results = indicators.get_doji(quotes, 0.1)
+        
+        r = results[0]
+        assert 212.80 == round(float(r.candle.close), 2)
+        assert   1.83 == round(float(r.candle.size), 2)
+        assert   0.19 == round(float(r.candle.body), 2)
+        assert   0.10 == round(float(r.candle.body_pct), 2)
+        assert   1.09 == round(float(r.candle.lower_wick), 2)
+        assert   0.60 == round(float(r.candle.lower_wick_pct), 2)
+        assert   0.55 == round(float(r.candle.upper_wick), 2)
+        assert   0.30 == round(float(r.candle.upper_wick_pct), 2)
+        assert r.candle.is_bearish == False
+        assert r.candle.is_bullish == True
+        
+        r = results[351]
+        assert 263.16 == round(float(r.candle.close), 2)
+        assert   1.24 == round(float(r.candle.size), 2)
+        assert   0.00 == round(float(r.candle.body), 2)
+        assert   0.00 == round(float(r.candle.body_pct), 2)
+        assert   0.55 == round(float(r.candle.lower_wick), 2)
+        assert   0.44 == round(float(r.candle.lower_wick_pct), 2)
+        assert   0.69 == round(float(r.candle.upper_wick), 2)
+        assert   0.56 == round(float(r.candle.upper_wick_pct), 2)
+        assert r.candle.is_bearish == False
+        assert r.candle.is_bullish == False
+        
+        r = results[501] 
+        assert 245.28 == round(float(r.candle.close), 2)
+        assert   2.67 == round(float(r.candle.size), 2)
+        assert   0.36 == round(float(r.candle.body), 2)
+        assert   0.13 == round(float(r.candle.body_pct), 2)
+        assert   2.05 == round(float(r.candle.lower_wick), 2)
+        assert   0.77 == round(float(r.candle.lower_wick_pct), 2)
+        assert   0.26 == round(float(r.candle.upper_wick), 2)
+        assert   0.10 == round(float(r.candle.upper_wick_pct), 2)
+        assert r.candle.is_bearish == False
+        assert r.candle.is_bullish == True


### PR DESCRIPTION
### Description

 - FATAL. It was not able to access candle properties.
 - Fix wrapping CandleProperties.
 - Add tests for candle properties.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
