### PR TITLE
feat: Remove clr load handling on x64 darwin

### DIFF
--- a/stock_indicators/_cslib/__init__.py
+++ b/stock_indicators/_cslib/__init__.py
@@ -9,21 +9,10 @@ It is currently using `.NET 6.0`.
 """
 
 import os
-import sys
 from pythonnet import load
-from clr_loader.util.find import find_dotnet_cli
 
 try:
-    if sys.platform == "darwin":
-        if sys.maxsize > 2**32:
-            dotnet_root = find_dotnet_cli().resolve().parent
-        else:
-            dotnet_root = "/usr/local/share/dotnet"
-    else:
-        dotnet_root = None
-    load(runtime="coreclr",
-        runtime_config=os.path.join(os.path.dirname(__file__), 'runtimeconfig.json'),
-        dotnet_root=dotnet_root)
+    load(runtime="coreclr", runtime_config=os.path.join(os.path.dirname(__file__), 'runtimeconfig.json'))
     import clr
 except Exception as e:
     raise ImportError(("fail to import clr.\n"


### PR DESCRIPTION
### Description

 - Remove clr load handling on x64 darwin
 - https://github.com/pythonnet/clr-loader/pull/37 accepted and released.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
