### PR TITLE
chore: Bump version to v1.0.0

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,3 +1,5 @@
+next-version: 0.0.0
+
 mode: ContinuousDelivery
 
 commit-message-incrementing: Enabled


### PR DESCRIPTION
### Description

 - `+semver: major` not worked before v1.
 - https://gitversion.net/docs/reference/version-increments
 - https://github.com/GitTools/GitVersion/issues/1539

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
