### PR TITLE
add Cloudflare pages deployer

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,61 @@
+name: Deploy website
+
+on: [workflow_dispatch]
+
+concurrency:
+  group: cloudflare-pages
+
+env:
+  JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  deploy:
+    name: Cloudflare Pages
+    runs-on: ubuntu-latest
+
+    environment:
+      name: cloudflare-pages
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          working-directory: docs
+          ruby-version: 3.1.3
+          bundler-cache: false
+
+      - name: Install GEMs
+        working-directory: docs
+        env:
+          BUNDLE_GEMFILE: ${{github.workspace}}/docs/GemFile
+        run: |
+          pwd
+          bundle install
+
+      - name: Build site (production)
+        if: github.ref == 'refs/heads/main'
+        working-directory: docs
+        env:
+          JEKYLL_ENV: production
+          BUNDLE_GEMFILE: ${{github.workspace}}/docs/GemFile
+        run: bundle exec jekyll build
+
+      - name: Build site (preview)
+        if: github.ref != 'refs/heads/main'
+        working-directory: docs
+        env:
+          JEKYLL_ENV: preview
+          BUNDLE_GEMFILE: ${{github.workspace}}/docs/GemFile
+        run: bundle exec jekyll build
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_KEY }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+          directory: docs/_site
+          wranglerVersion: 'latest'

--- a/.github/workflows/docs-test-a11y.yml
+++ b/.github/workflows/docs-test-a11y.yml
@@ -1,16 +1,17 @@
-name: test docs
+name: Website
 on:
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
+      - ".github/workflows/docs-test-a11y.yml"
 
 env:
   JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   testing:
-    name: a11y
+    name: test a11y
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs-test-links.yml
+++ b/.github/workflows/docs-test-links.yml
@@ -67,6 +67,6 @@ jobs:
         run: |
           htmlproofer _site \
             --no-enforce-https \
-            --ignore-status-codes "403,406,408,429,503,999" \
+            --ignore-status-codes "0,403,406,408,429,503,999" \
             --swap-urls "https\://python.stockindicators.dev:http\://127.0.0.1:4000" \
             --ignore-urls "/fonts.gstatic.com/"

--- a/.github/workflows/docs-test-links.yml
+++ b/.github/workflows/docs-test-links.yml
@@ -1,16 +1,17 @@
-name: test docs
+name: Website
 on:
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
+      - ".github/workflows/docs-test-links.yml"
 
 env:
   JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   testing:
-    name: URLs
+    name: test URLs
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Stock Indicators for Python** is a PyPI library package that produces financial market technical indicators.  Send in historical price quotes and get back desired indicators such as moving averages, Relative Strength Index, Stochastic Oscillator, Parabolic SAR, etc.  Nothing more.
 
-It can be used in any market analysis software using standard OHLCV price quotes for equities, commodities, forex, cryptocurrencies, and others.  We had private trading algorithms, machine learning, and charting systems in mind when originally creating this community library.  [Stock Indicators for .NET](https://https://dotnet.stockindicators.dev/) is also available.
+It can be used in any market analysis software using standard OHLCV price quotes for equities, commodities, forex, cryptocurrencies, and others.  We had private trading algorithms, machine learning, and charting systems in mind when originally creating this community library.  [Stock Indicators for .NET](https://dotnet.stockindicators.dev/) is also available.
 
 Visit our project site for more information:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Stock Indicators for Python** is a PyPI library package that produces financial market technical indicators.  Send in historical price quotes and get back desired indicators such as moving averages, Relative Strength Index, Stochastic Oscillator, Parabolic SAR, etc.  Nothing more.
 
-It can be used in any market analysis software using standard OHLCV price quotes for equities, commodities, forex, cryptocurrencies, and others.  We had private trading algorithms, machine learning, and charting systems in mind when originally creating this community library.  [Stock Indicators for .NET](https://https://daveskender.github.io/Stock.Indicators/) is also available.
+It can be used in any market analysis software using standard OHLCV price quotes for equities, commodities, forex, cryptocurrencies, and others.  We had private trading algorithms, machine learning, and charting systems in mind when originally creating this community library.  [Stock Indicators for .NET](https://https://dotnet.stockindicators.dev/) is also available.
 
 Visit our project site for more information:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![image](https://raw.githubusercontent.com/DaveSkender/Stock.Indicators.Python/main/docs/assets/social-banner.png)](https://daveskender.github.io/Stock.Indicators.Python/)
+[![image](https://raw.githubusercontent.com/DaveSkender/Stock.Indicators.Python/main/docs/assets/social-banner.png)](https://python.stockindicators.dev/)
 
 [![PyPI](https://img.shields.io/pypi/v/stock-indicators?color=blue&label=PyPI)](https://badge.fury.io/py/stock-indicators)
 [![code coverage](https://img.shields.io/azure-devops/coverage/skender/stock.indicators/26/main?logo=AzureDevOps&label=Test%20Coverage)](https://dev.azure.com/skender/Stock.Indicators/_build/latest?definitionId=26&branchName=main&view=codecoverage-tab)
@@ -11,9 +11,9 @@ It can be used in any market analysis software using standard OHLCV price quotes
 
 Visit our project site for more information:
 
-- [Overview](https://daveskender.github.io/Stock.Indicators.Python/)
-- [Indicators and overlays](https://daveskender.github.io/Stock.Indicators.Python/indicators/)
-- [Guide and Pro tips](https://daveskender.github.io/Stock.Indicators.Python/guide/)
+- [Overview](https://python.stockindicators.dev/)
+- [Indicators and overlays](https://python.stockindicators.dev/indicators/)
+- [Guide and Pro tips](https://python.stockindicators.dev/guide/)
 - [Release notes](https://github.com/DaveSkender/Stock.Indicators.Python/releases)
 - [Discussions](https://github.com/DaveSkender/Stock.Indicators/discussions)
 - [Contributing](https://github.com/DaveSkender/Stock.Indicators.Python/blob/main/docs/contributing.md#readme)

--- a/docs/GemFile.lock
+++ b/docs/GemFile.lock
@@ -8,7 +8,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.1)
+    activesupport (7.1.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -18,10 +18,10 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    base64 (0.1.1)
-    bigdecimal (3.1.4)
+    base64 (0.2.0)
+    bigdecimal (3.1.5)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -32,7 +32,7 @@ GEM
     connection_pool (2.4.1)
     dnsruby (1.70.0)
       simpleidn (~> 0.2.1)
-    drb (2.1.1)
+    drb (2.2.0)
       ruby2_keywords
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -40,7 +40,7 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     execjs (2.9.1)
-    faraday (2.7.11)
+    faraday (2.8.1)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -233,8 +233,8 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.20.0)
-    mutex_m (0.1.2)
-    nokogiri (1.15.4)
+    mutex_m (0.2.0)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -244,7 +244,7 @@ GEM
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
     public_suffix (4.0.7)
-    racc (1.7.2)
+    racc (1.7.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -265,13 +265,13 @@ GEM
       unf (~> 0.1.4)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    typhoeus (1.4.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
+    unf_ext (0.0.9.1)
     unicode-display_width (1.8.0)
     wdm (0.1.1)
     webrick (1.8.1)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 # Ref: https://jekyllrb.com/docs/usage/
 # Ref: https://github.com/pages-themes/cayman
-# Local dev: bundle exec jekyll serve --livereload
+# Local dev: bundle exec jekyll serve -o -l
 
 title: "Stock Indicators for Python"
 tagline: "Send in historical price quotes and get back desired technical indicators.  Nothing more."

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -153,7 +153,7 @@ This repository uses a standard Apache 2.0 open-source license.  It enables open
 
 ## Contact info
 
-[Start a new discussion, ask a question](https://github.com/DaveSkender/Stock.Indicators/discussions), or [submit an issue](https://daveskender.github.io/Stock.Indicators.Python/contributing/#reporting-bugs-and-feature-requests) if it is publicly relevant.  You can also direct message [@daveskender](https://twitter.com/messages/compose?recipient_id=27475431).
+[Start a new discussion, ask a question](https://github.com/DaveSkender/Stock.Indicators/discussions), or [submit an issue](https://python.stockindicators.dev/contributing/#reporting-bugs-and-feature-requests) if it is publicly relevant.  You can also direct message [@daveskender](https://twitter.com/messages/compose?recipient_id=27475431).
 
 Thanks,
 Dave Skender

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -14,7 +14,7 @@ lazy-images: true
 
 **Stock Indicators for Python** is a library that produces financial market technical indicators.  Send in historical price quotes and get back desired indicators such as moving averages, Relative Strength Index, Stochastic Oscillator, Parabolic SAR, etc.  Nothing more.
 
-It can be used in any market analysis software using standard OHLCV price quotes for equities, commodities, forex, cryptocurrencies, and others.  We had private trading algorithms, machine learning, and charting systems in mind when originally creating this community library.  [Stock Indicators for .NET](https://daveskender.github.io/Stock.Indicators) is also available.
+It can be used in any market analysis software using standard OHLCV price quotes for equities, commodities, forex, cryptocurrencies, and others.  We had private trading algorithms, machine learning, and charting systems in mind when originally creating this community library.  [Stock Indicators for .NET](https://dotnet.stockindicators.dev) is also available.
 
 Explore more information:
 

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setuptools.setup(
     description="Stock Indicators for Python.  Send in historical price quotes and get back desired technical indicators such as Stochastic RSI, Average True Range, Parabolic SAR, etc.  Nothing more.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://daveskender.github.io/Stock.Indicators.Python",
+    url="https://python.stockindicators.dev",
     project_urls={
         "Bug Tracker": "https://github.com/DaveSkender/Stock.Indicators.Python/issues",
-        "Documentation": "https://daveskender.github.io/Stock.Indicators.Python",
+        "Documentation": "https://python.stockindicators.dev",
         "Source Code": "https://github.com/DaveSkender/Stock.Indicators.Python/tree/main",
     },
     license="Apache 2.0",

--- a/stock_indicators/indicators/adl.py
+++ b/stock_indicators/indicators/adl.py
@@ -23,8 +23,8 @@ def get_adl(quotes: Iterable[Quote], sma_periods: Optional[int] = None):
             ADLResults is list of ADLResult with providing useful helper methods.
 
     See more:
-         - [ADL Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Adl/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [ADL Reference](https://python.stockindicators.dev/indicators/Adl/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     adl_results = CsIndicator.GetAdl[Quote](CsList(Quote, quotes), sma_periods)
     return ADLResults(adl_results, ADLResult)

--- a/stock_indicators/indicators/adx.py
+++ b/stock_indicators/indicators/adx.py
@@ -25,8 +25,8 @@ def get_adx(quotes: Iterable[Quote], lookback_periods: int = 14):
             ADXResults is list of ADXResult with providing useful helper methods.
 
     See more:
-         - [ADX Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Adx/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [ADX Reference](https://python.stockindicators.dev/indicators/Adx/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     adx_results = CsIndicator.GetAdx[Quote](CsList(Quote, quotes), lookback_periods)
     return ADXResults(adx_results, ADXResult)

--- a/stock_indicators/indicators/alligator.py
+++ b/stock_indicators/indicators/alligator.py
@@ -44,8 +44,8 @@ def get_alligator(quotes: Iterable[Quote],
             AlligatorResults is list of AlligatorResult with providing useful helper methods.
 
     See more:
-         - [Williams Alligator Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Alligator/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Williams Alligator Reference](https://python.stockindicators.dev/indicators/Alligator/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     alligator_results = CsIndicator.GetAlligator[Quote](CsList(Quote, quotes),
                                                         jaw_periods, jaw_offset,

--- a/stock_indicators/indicators/alma.py
+++ b/stock_indicators/indicators/alma.py
@@ -31,8 +31,8 @@ def get_alma(quotes: Iterable[Quote], lookback_periods: int = 9, offset: float =
             ALMAResults is list of ALMAResult with providing useful helper methods.
 
     See more:
-         - [ALMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Alma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [ALMA Reference](https://python.stockindicators.dev/indicators/Alma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     alma_results = CsIndicator.GetAlma[Quote](CsList(Quote, quotes), lookback_periods, offset, sigma)
     return ALMAResults(alma_results, ALMAResult)

--- a/stock_indicators/indicators/aroon.py
+++ b/stock_indicators/indicators/aroon.py
@@ -24,8 +24,8 @@ def get_aroon(quotes: Iterable[Quote], lookback_periods: int = 25):
             AroonResults is list of AroonResult with providing useful helper methods.
 
     See more:
-         - [Aroon Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Aroon/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Aroon Reference](https://python.stockindicators.dev/indicators/Aroon/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     aroon_results = CsIndicator.GetAroon[Quote](CsList(Quote, quotes), lookback_periods)
     return AroonResults(aroon_results, AroonResult)

--- a/stock_indicators/indicators/atr.py
+++ b/stock_indicators/indicators/atr.py
@@ -24,8 +24,8 @@ def get_atr(quotes: Iterable[Quote], lookback_periods: int = 14):
             ATRResults is list of ATRResult with providing useful helper methods.
 
     See more:
-         - [ATR Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Atr/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [ATR Reference](https://python.stockindicators.dev/indicators/Atr/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     atr_results = CsIndicator.GetAtr[Quote](CsList(Quote, quotes), lookback_periods)
     return ATRResults(atr_results, ATRResult)

--- a/stock_indicators/indicators/awesome.py
+++ b/stock_indicators/indicators/awesome.py
@@ -28,8 +28,8 @@ def get_awesome(quotes: Iterable[Quote], fast_periods: int = 5, slow_periods: in
             AwesomeResults is list of AwesomeResult with providing useful helper methods.
 
     See more:
-         - [Awesome Oscillator Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Awesome/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Awesome Oscillator Reference](https://python.stockindicators.dev/indicators/Awesome/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     awesome_results = CsIndicator.GetAwesome[Quote](CsList(Quote, quotes), fast_periods, slow_periods)
     return AwesomeResults(awesome_results, AwesomeResult)

--- a/stock_indicators/indicators/basic_quotes.py
+++ b/stock_indicators/indicators/basic_quotes.py
@@ -25,8 +25,8 @@ def get_basic_quote(quotes: Iterable[Quote], candle_part: CandlePart = CandlePar
             BasicQuoteResults is list of BasicQuoteResult with providing useful helper methods.
 
     See more:
-         - [Basic Quote Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/BasicQuote/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Basic Quote Reference](https://python.stockindicators.dev/indicators/BasicQuote/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetBaseQuote[Quote](CsList(Quote, quotes), candle_part.cs_value)
     return BasicQuoteResults(results, BasicQuoteResult)

--- a/stock_indicators/indicators/beta.py
+++ b/stock_indicators/indicators/beta.py
@@ -32,8 +32,8 @@ def get_beta(eval_quotes: Iterable[Quote], market_quotes: Iterable[Quote],
             BetaResults is list of BetaResult with providing useful helper methods.
 
     See more:
-         - [Beta Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Beta/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Beta Reference](https://python.stockindicators.dev/indicators/Beta/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
 
     beta_results = CsIndicator.GetBeta[Quote](CsList(Quote, eval_quotes), CsList(Quote, market_quotes),

--- a/stock_indicators/indicators/bollinger_bands.py
+++ b/stock_indicators/indicators/bollinger_bands.py
@@ -28,8 +28,8 @@ def get_bollinger_bands(quotes: Iterable[Quote], lookback_periods: int = 20, sta
             BollingerBandsResults is list of BollingerBandsResult with providing useful helper methods.
 
     See more:
-         - [Bollinger Bands&#174; Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/BollingerBands/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Bollinger Bands&#174; Reference](https://python.stockindicators.dev/indicators/BollingerBands/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     bollinger_bands_results = CsIndicator.GetBollingerBands[Quote](CsList(Quote, quotes), lookback_periods, standard_deviations)
     return BollingerBandsResults(bollinger_bands_results, BollingerBandsResult)

--- a/stock_indicators/indicators/bop.py
+++ b/stock_indicators/indicators/bop.py
@@ -25,8 +25,8 @@ def get_bop(quotes: Iterable[Quote], smooth_periods: int = 14):
             BOPResults is list of BOPResult with providing useful helper methods.
 
     See more:
-         - [BOP Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Bop/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [BOP Reference](https://python.stockindicators.dev/indicators/Bop/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetBop[Quote](CsList(Quote, quotes), smooth_periods)
     return BOPResults(results, BOPResult)

--- a/stock_indicators/indicators/cci.py
+++ b/stock_indicators/indicators/cci.py
@@ -25,8 +25,8 @@ def get_cci(quotes: Iterable[Quote], lookback_periods: int = 20):
             CCIResults is list of CCIResult with providing useful helper methods.
 
     See more:
-         - [CCI Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Cci/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [CCI Reference](https://python.stockindicators.dev/indicators/Cci/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetCci[Quote](CsList(Quote, quotes), lookback_periods)
     return CCIResults(results, CCIResult)

--- a/stock_indicators/indicators/chaikin_oscillator.py
+++ b/stock_indicators/indicators/chaikin_oscillator.py
@@ -28,8 +28,8 @@ def get_chaikin_osc(quotes: Iterable[Quote], fast_periods: int = 3, slow_periods
             ChaikinOscResults is list of ChaikinOscResult with providing useful helper methods.
 
     See more:
-         - [Chaikin Oscillator Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/ChaikinOsc/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Chaikin Oscillator Reference](https://python.stockindicators.dev/indicators/ChaikinOsc/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetChaikinOsc[Quote](CsList(Quote, quotes), fast_periods, slow_periods)
     return ChaikinOscResults(results, ChaikinOscResult)

--- a/stock_indicators/indicators/chandelier.py
+++ b/stock_indicators/indicators/chandelier.py
@@ -33,8 +33,8 @@ def get_chandelier(quotes: Iterable[Quote], lookback_periods: int = 22,
             ChandelierResults is list of ChandelierResult with providing useful helper methods.
 
     See more:
-         - [Chandelier Exit Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Chandelier/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Chandelier Exit Reference](https://python.stockindicators.dev/indicators/Chandelier/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetChandelier[Quote](CsList(Quote, quotes), lookback_periods,
                                                multiplier, chandelier_type.cs_value)

--- a/stock_indicators/indicators/chop.py
+++ b/stock_indicators/indicators/chop.py
@@ -25,8 +25,8 @@ def get_chop(quotes: Iterable[Quote], lookback_periods: int = 14):
             ChopResults is list of ChopResult with providing useful helper methods.
 
     See more:
-         - [Choppiness Index Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Chop/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Choppiness Index Reference](https://python.stockindicators.dev/indicators/Chop/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetChop[Quote](CsList(Quote, quotes), lookback_periods)
     return ChopResults(results, ChopResult)

--- a/stock_indicators/indicators/cmf.py
+++ b/stock_indicators/indicators/cmf.py
@@ -25,8 +25,8 @@ def get_cmf(quotes: Iterable[Quote], lookback_periods: int = 20):
             CMFResults is list of CMFResult with providing useful helper methods.
 
     See more:
-         - [CMF Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Cmf/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [CMF Reference](https://python.stockindicators.dev/indicators/Cmf/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetCmf[Quote](CsList(Quote, quotes), lookback_periods)
     return CMFResults(results, CMFResult)

--- a/stock_indicators/indicators/connors_rsi.py
+++ b/stock_indicators/indicators/connors_rsi.py
@@ -32,8 +32,8 @@ def get_connors_rsi(quotes: Iterable[Quote], rsi_periods: int = 3,
             ConnorsRSIResults is list of ConnorsRSIResult with providing useful helper methods.
 
     See more:
-         - [Connors RSI Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/ConnorsRsi/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Connors RSI Reference](https://python.stockindicators.dev/indicators/ConnorsRsi/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetConnorsRsi[Quote](CsList(Quote, quotes), rsi_periods,
                                                streak_periods, rank_periods)

--- a/stock_indicators/indicators/correlation.py
+++ b/stock_indicators/indicators/correlation.py
@@ -28,8 +28,8 @@ def get_correlation(quotes_a: Iterable[Quote], quotes_b: Iterable[Quote],
             CorrelationResults is list of CorrelationResult with providing useful helper methods.
 
     See more:
-         - [Correlation Coefficient Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Correlation/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Correlation Coefficient Reference](https://python.stockindicators.dev/indicators/Correlation/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetCorrelation[Quote](CsList(Quote, quotes_a), CsList(Quote, quotes_b),
                                                 lookback_periods)

--- a/stock_indicators/indicators/dema.py
+++ b/stock_indicators/indicators/dema.py
@@ -24,8 +24,8 @@ def get_dema(quotes: Iterable[Quote], lookback_periods: int):
             DEMAResults is list of DEMAResult with providing useful helper methods.
 
     See more:
-         - [DEMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/DoubleEma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [DEMA Reference](https://python.stockindicators.dev/indicators/DoubleEma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetDema[Quote](CsList(Quote, quotes), lookback_periods)
     return DEMAResults(results, DEMAResult)

--- a/stock_indicators/indicators/doji.py
+++ b/stock_indicators/indicators/doji.py
@@ -25,8 +25,8 @@ def get_doji(quotes: Iterable[Quote], max_price_change_percent: float = 0.1):
             CandleResults is list of CandleResult with providing useful helper methods.
 
     See more:
-         - [Doji Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Doji/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Doji Reference](https://python.stockindicators.dev/indicators/Doji/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetDoji[Quote](CsList(Quote, quotes), max_price_change_percent)
     return CandleResults(results, CandleResult)

--- a/stock_indicators/indicators/donchian.py
+++ b/stock_indicators/indicators/donchian.py
@@ -27,8 +27,8 @@ def get_donchian(quotes: Iterable[Quote], lookback_periods: int = 20):
             DonchianResults is list of DonchianResult with providing useful helper methods.
 
     See more:
-         - [Donchian Channels Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Donchian/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Donchian Channels Reference](https://python.stockindicators.dev/indicators/Donchian/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetDonchian[Quote](CsList(Quote, quotes), lookback_periods)
     return DonchianResults(results, DonchianResult)

--- a/stock_indicators/indicators/dpo.py
+++ b/stock_indicators/indicators/dpo.py
@@ -24,8 +24,8 @@ def get_dpo(quotes: Iterable[Quote], lookback_periods: int):
             DPOResults is list of DPOResult with providing useful helper methods.
 
     See more:
-         - [DPO Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Dpo/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [DPO Reference](https://python.stockindicators.dev/indicators/Dpo/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetDpo[Quote](CsList(Quote, quotes), lookback_periods)
     return DPOResults(results, DPOResult)

--- a/stock_indicators/indicators/elder_ray.py
+++ b/stock_indicators/indicators/elder_ray.py
@@ -24,8 +24,8 @@ def get_elder_ray(quotes: Iterable[Quote], lookback_periods: int = 13):
             ElderRayResults is list of ElderRayResult with providing useful helper methods.
 
     See more:
-         - [Elder-ray Index Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/ElderRay/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Elder-ray Index Reference](https://python.stockindicators.dev/indicators/ElderRay/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetElderRay[Quote](CsList(Quote, quotes), lookback_periods)
     return ElderRayResults(results, ElderRayResult)

--- a/stock_indicators/indicators/ema.py
+++ b/stock_indicators/indicators/ema.py
@@ -28,8 +28,8 @@ def get_ema(quotes: Iterable[Quote], lookback_periods: int,
             EMAResults is list of EMAResult with providing useful helper methods.
 
     See more:
-         - [EMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Ema/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [EMA Reference](https://python.stockindicators.dev/indicators/Ema/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     quotes = Quote.use(quotes, candle_part) # Error occurs if not assigned to local var.
     ema_list = CsIndicator.GetEma(quotes, lookback_periods)

--- a/stock_indicators/indicators/epma.py
+++ b/stock_indicators/indicators/epma.py
@@ -26,8 +26,8 @@ def get_epma(quotes: Iterable[Quote], lookback_periods: int):
             EPMAResults is list of EPMAResult with providing useful helper methods.
 
     See more:
-         - [EPMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Epma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [EPMA Reference](https://python.stockindicators.dev/indicators/Epma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetEpma[Quote](CsList(Quote, quotes), lookback_periods)
     return EPMAResults(results, EPMAResult)

--- a/stock_indicators/indicators/fcb.py
+++ b/stock_indicators/indicators/fcb.py
@@ -29,8 +29,8 @@ def get_fcb(quotes: Iterable[Quote], window_span: int = 2):
             FCBResults is list of FCBResult with providing useful helper methods.
 
     See more:
-         - [FCB Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Fcb/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [FCB Reference](https://python.stockindicators.dev/indicators/Fcb/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetFcb[Quote](CsList(Quote, quotes), window_span)
     return FCBResults(results, FCBResult)

--- a/stock_indicators/indicators/fisher_transform.py
+++ b/stock_indicators/indicators/fisher_transform.py
@@ -25,8 +25,8 @@ def get_fisher_transform(quotes: Iterable[Quote], lookback_periods: int = 10):
             FisherTransformResult with providing useful helper methods.
 
     See more:
-         - [Fisher Transform Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/FisherTransform/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Fisher Transform Reference](https://python.stockindicators.dev/indicators/FisherTransform/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetFisherTransform[Quote](CsList(Quote, quotes), lookback_periods)
     return FisherTransformResults(results, FisherTransformResult)

--- a/stock_indicators/indicators/force_index.py
+++ b/stock_indicators/indicators/force_index.py
@@ -24,8 +24,8 @@ def get_force_index(quotes: Iterable[Quote], lookback_periods: int):
             ForceIndexResults is list of ForceIndexResult with providing useful helper methods.
 
     See more:
-         - [Force Index Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/ForceIndex/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Force Index Reference](https://python.stockindicators.dev/indicators/ForceIndex/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetForceIndex[Quote](CsList(Quote, quotes), lookback_periods)
     return ForceIndexResults(results, ForceIndexResult)

--- a/stock_indicators/indicators/fractal.py
+++ b/stock_indicators/indicators/fractal.py
@@ -41,8 +41,8 @@ def get_fractal(quotes, left_span = None, right_span = EndType.HIGH_LOW, end_typ
             FractalResults is list of FractalResult with providing useful helper methods.
 
     See more:
-         - [Williams Fractal Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Fractal/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Williams Fractal Reference](https://python.stockindicators.dev/indicators/Fractal/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     if isinstance(right_span, EndType):
         if left_span is None: left_span = 2

--- a/stock_indicators/indicators/gator.py
+++ b/stock_indicators/indicators/gator.py
@@ -25,8 +25,8 @@ def get_gator(quotes):
             GatorResults is list of GatorResult with providing useful helper methods.
 
     See more:
-         - [Gator Oscillator Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Gator/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Gator Oscillator Reference](https://python.stockindicators.dev/indicators/Gator/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     if not quotes or isinstance(quotes[0], Quote):
         results = CsIndicator.GetGator[Quote](CsList(Quote, quotes))

--- a/stock_indicators/indicators/heikin_ashi.py
+++ b/stock_indicators/indicators/heikin_ashi.py
@@ -23,8 +23,8 @@ def get_heikin_ashi(quotes: Iterable[Quote]):
             HeikinAshiResults is list of HeikinAshiResult with providing useful helper methods.
 
     See more:
-         - [Heikin-Ashi Channels Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/HeikinAshi/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Heikin-Ashi Channels Reference](https://python.stockindicators.dev/indicators/HeikinAshi/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetHeikinAshi[Quote](CsList(Quote, quotes))
     return HeikinAshiResults(results, HeikinAshiResult)

--- a/stock_indicators/indicators/hma.py
+++ b/stock_indicators/indicators/hma.py
@@ -25,8 +25,8 @@ def get_hma(quotes: Iterable[Quote], lookback_periods: int):
             HMAResults is list of HMAResult with providing useful helper methods.
 
     See more:
-         - [HMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Hma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [HMA Reference](https://python.stockindicators.dev/indicators/Hma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetHma[Quote](CsList(Quote, quotes), lookback_periods)
     return HMAResults(results, HMAResult)

--- a/stock_indicators/indicators/ht_trendline.py
+++ b/stock_indicators/indicators/ht_trendline.py
@@ -22,8 +22,8 @@ def get_ht_trendline(quotes: Iterable[Quote]):
             HTTrendlineResults is list of HTTrendlineResult with providing useful helper methods.
 
     See more:
-         - [HTL Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/HtTrendline/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [HTL Reference](https://python.stockindicators.dev/indicators/HtTrendline/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetHtTrendline[Quote](CsList(Quote, quotes))
     return HTTrendlineResults(results, HTTrendlineResult)

--- a/stock_indicators/indicators/hurst.py
+++ b/stock_indicators/indicators/hurst.py
@@ -25,8 +25,8 @@ def get_hurst(quotes: Iterable[Quote], lookback_periods: int = 100):
             HurstResults is list of HurstResult with providing useful helper methods.
 
     See more:
-         - [Hurst Exponent Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Hurst/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Hurst Exponent Reference](https://python.stockindicators.dev/indicators/Hurst/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetHurst[Quote](CsList(Quote, quotes), lookback_periods)
     return HurstResults(results, HurstResult)

--- a/stock_indicators/indicators/ichimoku.py
+++ b/stock_indicators/indicators/ichimoku.py
@@ -56,8 +56,8 @@ def get_ichimoku(quotes: Iterable[Quote], tenkan_periods: int = None,
             IchimokuResults is list of IchimokuResult with providing useful helper methods.
 
     See more:
-         - [Ichimoku Cloud Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Ichimoku/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Ichimoku Cloud Reference](https://python.stockindicators.dev/indicators/Ichimoku/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     if chikou_offset is None:
         if senkou_offset is None:

--- a/stock_indicators/indicators/kama.py
+++ b/stock_indicators/indicators/kama.py
@@ -35,8 +35,8 @@ def get_kama(quotes: Iterable[Quote], er_periods: int = 10,
             KAMAResults is list of KAMAResult with providing useful helper methods.
 
     See more:
-         - [KAMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Kama/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [KAMA Reference](https://python.stockindicators.dev/indicators/Kama/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetKama[Quote](CsList(Quote, quotes), er_periods,
                                          fast_periods, slow_periods)

--- a/stock_indicators/indicators/keltner.py
+++ b/stock_indicators/indicators/keltner.py
@@ -32,8 +32,8 @@ def get_keltner(quotes: Iterable[Quote], ema_periods: int = 20,
             KeltnerResults is list of KeltnerResult with providing useful helper methods.
 
     See more:
-         - [Keltner Channels Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Keltner/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Keltner Channels Reference](https://python.stockindicators.dev/indicators/Keltner/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetKeltner[Quote](CsList(Quote, quotes), ema_periods,
                                             multiplier, atr_periods)

--- a/stock_indicators/indicators/kvo.py
+++ b/stock_indicators/indicators/kvo.py
@@ -32,8 +32,8 @@ def get_kvo(quotes: Iterable[Quote], fast_periods: int = 34,
             KVOResults is list of KVOResult with providing useful helper methods.
 
     See more:
-         - [KVO Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Kvo/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [KVO Reference](https://python.stockindicators.dev/indicators/Kvo/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetKvo[Quote](CsList(Quote, quotes), fast_periods,
                                         slow_periods, signal_periods)

--- a/stock_indicators/indicators/ma_envelopes.py
+++ b/stock_indicators/indicators/ma_envelopes.py
@@ -32,8 +32,8 @@ def get_ma_envelopes(quotes: Iterable[Quote], lookback_periods: int,
             MAEnvelopeResults is list of MAEnvelopeResult with providing useful helper methods.
 
     See more:
-         - [Moving Average Envelopes Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/MaEnvelopes/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Moving Average Envelopes Reference](https://python.stockindicators.dev/indicators/MaEnvelopes/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetMaEnvelopes[Quote](CsList(Quote, quotes), lookback_periods,
                                             percent_offset, ma_type.cs_value)

--- a/stock_indicators/indicators/macd.py
+++ b/stock_indicators/indicators/macd.py
@@ -36,8 +36,8 @@ def get_macd(quotes: Iterable[Quote], fast_periods: int = 12,
             MACDResults is list of MACDResult with providing useful helper methods.
 
     See more:
-         - [MACD Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Macd/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [MACD Reference](https://python.stockindicators.dev/indicators/Macd/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     quotes = Quote.use(quotes, candle_part) # Error occurs if not assigned to local var.
     macd_results = CsIndicator.GetMacd(quotes, fast_periods,

--- a/stock_indicators/indicators/mama.py
+++ b/stock_indicators/indicators/mama.py
@@ -29,8 +29,8 @@ def get_mama(quotes: Iterable[Quote], fast_limit: float = 0.5,
             MAMAResults is list of MAMAResult with providing useful helper methods.
 
     See more:
-         - [MAMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Mama/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [MAMA Reference](https://python.stockindicators.dev/indicators/Mama/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetMama[Quote](CsList(Quote, quotes), fast_limit,
                                          slow_limit)

--- a/stock_indicators/indicators/marubozu.py
+++ b/stock_indicators/indicators/marubozu.py
@@ -25,8 +25,8 @@ def get_marubozu(quotes: Iterable[Quote], min_body_percent: float = 95):
             CandleResults is list of CandleResult with providing useful helper methods.
 
     See more:
-         - [Marubozu Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Marubozu/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Marubozu Reference](https://python.stockindicators.dev/indicators/Marubozu/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetMarubozu[Quote](CsList(Quote, quotes), min_body_percent)
     return CandleResults(results, CandleResult)

--- a/stock_indicators/indicators/mfi.py
+++ b/stock_indicators/indicators/mfi.py
@@ -25,8 +25,8 @@ def get_mfi(quotes: Iterable[Quote], lookback_periods: int = 14):
             MFIResults is list of MFIResult with providing useful helper methods.
 
     See more:
-         - [MFI Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Mfi/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [MFI Reference](https://python.stockindicators.dev/indicators/Mfi/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetMfi[Quote](CsList(Quote, quotes), lookback_periods)
     return MFIResults(results, MFIResult)

--- a/stock_indicators/indicators/obv.py
+++ b/stock_indicators/indicators/obv.py
@@ -24,8 +24,8 @@ def get_obv(quotes: Iterable[Quote], sma_periods: Optional[int] = None):
             OBVResults is list of OBVResult with providing useful helper methods.
 
     See more:
-         - [OBV Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Obv/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [OBV Reference](https://python.stockindicators.dev/indicators/Obv/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetObv[Quote](CsList(Quote, quotes), sma_periods)
     return OBVResults(results, OBVResult)

--- a/stock_indicators/indicators/parabolic_sar.py
+++ b/stock_indicators/indicators/parabolic_sar.py
@@ -38,8 +38,8 @@ def get_parabolic_sar(quotes, acceleration_step = None,
             ParabolicSARResults is list of ParabolicSARResult with providing useful helper methods.
 
     See more:
-         - [Parabolic SAR Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/ParabolicSar/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Parabolic SAR Reference](https://python.stockindicators.dev/indicators/ParabolicSar/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     if initial_factor is None:
         if acceleration_step is None: acceleration_step = 0.02

--- a/stock_indicators/indicators/pivot_points.py
+++ b/stock_indicators/indicators/pivot_points.py
@@ -34,8 +34,8 @@ def get_pivot_points(quotes, window_size: PeriodSize,
             PivotPointsResults is list of PivotPointsResult with providing useful helper methods.
 
     See more:
-         - [Pivot Points Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/PivotPoints/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Pivot Points Reference](https://python.stockindicators.dev/indicators/PivotPoints/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetPivotPoints[Quote](CsList(Quote, quotes), window_size.cs_value,
                                                  point_type.cs_value)

--- a/stock_indicators/indicators/pivots.py
+++ b/stock_indicators/indicators/pivots.py
@@ -40,8 +40,8 @@ def get_pivots(quotes: Iterable[Quote], left_span: int = 2,
             PivotsResults is list of PivotsResult with providing useful helper methods.
 
     See more:
-         - [Pivots Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Pivots/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Pivots Reference](https://python.stockindicators.dev/indicators/Pivots/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetPivots[Quote](CsList(Quote, quotes), left_span,
                                            right_span, max_trend_periods,

--- a/stock_indicators/indicators/pmo.py
+++ b/stock_indicators/indicators/pmo.py
@@ -32,8 +32,8 @@ def get_pmo(quotes: Iterable[Quote], time_periods: int = 35,
             PMOResults is list of PMOResult with providing useful helper methods.
 
     See more:
-         - [PMO Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Pmo/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [PMO Reference](https://python.stockindicators.dev/indicators/Pmo/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetPmo[Quote](CsList(Quote, quotes), time_periods,
                                         smooth_periods, signal_periods)

--- a/stock_indicators/indicators/prs.py
+++ b/stock_indicators/indicators/prs.py
@@ -35,8 +35,8 @@ def get_prs(eval_quotes: Iterable[Quote], base_quotes: Iterable[Quote],
             PRSResults is list of PRSResult with providing useful helper methods.
 
     See more:
-         - [PRS Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Prs/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [PRS Reference](https://python.stockindicators.dev/indicators/Prs/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
 
     results = CsIndicator.GetPrs[Quote](CsList(Quote, eval_quotes), CsList(Quote, base_quotes),

--- a/stock_indicators/indicators/pvo.py
+++ b/stock_indicators/indicators/pvo.py
@@ -32,8 +32,8 @@ def get_pvo(quotes: Iterable[Quote], fast_periods: int = 12,
             PVOResults is list of PVOResult with providing useful helper methods.
 
     See more:
-         - [PVO Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Pvo/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [PVO Reference](https://python.stockindicators.dev/indicators/Pvo/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetPvo[Quote](CsList(Quote, quotes), fast_periods,
                                            slow_periods, signal_periods)

--- a/stock_indicators/indicators/renko.py
+++ b/stock_indicators/indicators/renko.py
@@ -32,8 +32,8 @@ def get_renko(quotes: Iterable[Quote], brick_size: float,
             RenkoResults is list of RenkoResult with providing useful helper methods.
 
     See more:
-         - [Renko Chart Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Renko/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Renko Chart Reference](https://python.stockindicators.dev/indicators/Renko/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetRenko[Quote](CsList(Quote, quotes), CsDecimal(brick_size),
                                            end_type.cs_value)
@@ -62,8 +62,8 @@ def get_renko_atr(quotes: Iterable[Quote], atr_periods: int,
             RenkoResults is list of RenkoResult with providing useful helper methods.
 
     See more:
-         - [ATR Renko Chart Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Renko/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [ATR Renko Chart Reference](https://python.stockindicators.dev/indicators/Renko/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetRenkoAtr[Quote](CsList(Quote, quotes), atr_periods,
                                            end_type.cs_value)

--- a/stock_indicators/indicators/roc.py
+++ b/stock_indicators/indicators/roc.py
@@ -28,8 +28,8 @@ def get_roc(quotes: Iterable[Quote], lookback_periods: int, sma_periods: int = N
             ROCResults is list of ROCResult with providing useful helper methods.
 
     See more:
-         - [ROC Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Roc/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [ROC Reference](https://python.stockindicators.dev/indicators/Roc/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetRoc[Quote](CsList(Quote, quotes), lookback_periods, sma_periods)
     return ROCResults(results, ROCResult)
@@ -58,8 +58,8 @@ def get_roc_with_band(quotes: Iterable[Quote], lookback_periods: int, ema_period
             ROCWBResults is list of ROCWBResult with providing useful helper methods.
 
     See more:
-         - [ROCWB Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Roc/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [ROCWB Reference](https://python.stockindicators.dev/indicators/Roc/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetRocWb[Quote](CsList(Quote, quotes), lookback_periods, ema_periods, std_dev_periods)
     return ROCWBResults(results, ROCWBResult)

--- a/stock_indicators/indicators/rolling_pivots.py
+++ b/stock_indicators/indicators/rolling_pivots.py
@@ -36,8 +36,8 @@ def get_rolling_pivots(quotes: Iterable[Quote], window_periods: int,
             RollingPivotsResults is list of RollingPivotsResult with providing useful helper methods.
 
     See more:
-         - [Rolling Pivot Points Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/RollingPivots/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Rolling Pivot Points Reference](https://python.stockindicators.dev/indicators/RollingPivots/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetRollingPivots[Quote](CsList(Quote, quotes), window_periods,
                                                  offset_periods, point_type.cs_value)

--- a/stock_indicators/indicators/rsi.py
+++ b/stock_indicators/indicators/rsi.py
@@ -25,8 +25,8 @@ def get_rsi(quotes: Iterable[Quote], lookback_periods: int = 14):
             RSIResults is list of RSIResult with providing useful helper methods.
 
     See more:
-         - [RSI Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Rsi/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [RSI Reference](https://python.stockindicators.dev/indicators/Rsi/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     rsi_list = CsIndicator.GetRsi[Quote](CsList(Quote, quotes), lookback_periods)
     return RSIResults(rsi_list, RSIResult)

--- a/stock_indicators/indicators/slope.py
+++ b/stock_indicators/indicators/slope.py
@@ -28,8 +28,8 @@ def get_slope(quotes: Iterable[Quote], lookback_periods: int):
             SlopeResults is list of SlopeResult with providing useful helper methods.
 
     See more:
-         - [Slope Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Slope/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Slope Reference](https://python.stockindicators.dev/indicators/Slope/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetSlope[Quote](CsList(Quote, quotes), lookback_periods)
     return SlopeResults(results, SlopeResult)

--- a/stock_indicators/indicators/sma.py
+++ b/stock_indicators/indicators/sma.py
@@ -29,8 +29,8 @@ def get_sma(quotes: Iterable[Quote], lookback_periods: int,
             SMAResults is list of SMAResult with providing useful helper methods.
 
     See more:
-         - [SMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Sma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [SMA Reference](https://python.stockindicators.dev/indicators/Sma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     quotes = Quote.use(
         quotes, candle_part)  # Error occurs if not assigned to local var.
@@ -57,8 +57,8 @@ def get_sma_analysis(quotes: Iterable[Quote], lookback_periods: int):
             SMAAnalysisResults is list of SMAAnalysisResult with providing useful helper methods.
 
     See more:
-         - [SMA-analysis Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Sma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [SMA-analysis Reference](https://python.stockindicators.dev/indicators/Sma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     sma_extended_list = CsIndicator.GetSmaAnalysis[Quote](
         CsList(Quote, quotes), lookback_periods)

--- a/stock_indicators/indicators/smi.py
+++ b/stock_indicators/indicators/smi.py
@@ -36,8 +36,8 @@ def get_smi(quotes: Iterable[Quote], lookback_periods: int,
             SMIResults is list of SMIResult with providing useful helper methods.
 
     See more:
-         - [SMI Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Smi/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [SMI Reference](https://python.stockindicators.dev/indicators/Smi/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetSmi[Quote](CsList(Quote, quotes), lookback_periods,
                                         first_smooth_periods, second_smooth_periods,

--- a/stock_indicators/indicators/smma.py
+++ b/stock_indicators/indicators/smma.py
@@ -25,8 +25,8 @@ def get_smma(quotes: Iterable[Quote], lookback_periods: int):
             SMMAResults is list of SMMAResult with providing useful helper methods.
 
     See more:
-         - [SMMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Smma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [SMMA Reference](https://python.stockindicators.dev/indicators/Smma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetSmma[Quote](CsList(Quote, quotes), lookback_periods)
     return SMMAResults(results, SMMAResult)

--- a/stock_indicators/indicators/starc_bands.py
+++ b/stock_indicators/indicators/starc_bands.py
@@ -32,8 +32,8 @@ def get_starc_bands(quotes: Iterable[Quote], sma_periods: int = 20,
             STARCBandsResults is list of STARCBandsResult with providing useful helper methods.
 
     See more:
-         - [STARC Bands Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/StarcBands/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [STARC Bands Reference](https://python.stockindicators.dev/indicators/StarcBands/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetStarcBands[Quote](CsList(Quote, quotes), sma_periods,
                                                multiplier, atr_periods)

--- a/stock_indicators/indicators/stc.py
+++ b/stock_indicators/indicators/stc.py
@@ -32,8 +32,8 @@ def get_stc(quotes: Iterable[Quote], cycle_periods: int = 10,
             STCResults is list of STCResult with providing useful helper methods.
 
     See more:
-         - [STC Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Stc/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [STC Reference](https://python.stockindicators.dev/indicators/Stc/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetStc[Quote](CsList(Quote, quotes), cycle_periods,
                                         fast_periods, slow_periods)

--- a/stock_indicators/indicators/stdev.py
+++ b/stock_indicators/indicators/stdev.py
@@ -28,8 +28,8 @@ def get_stdev(quotes: Iterable[Quote], lookback_periods: int,
             StdevResults is list of StdevResult with providing useful helper methods.
 
     See more:
-         - [Stdev Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/StdDev/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Stdev Reference](https://python.stockindicators.dev/indicators/StdDev/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetStdDev[Quote](CsList(Quote, quotes), lookback_periods, sma_periods)
     return StdevResults(results, StdevResult)

--- a/stock_indicators/indicators/stdev_channels.py
+++ b/stock_indicators/indicators/stdev_channels.py
@@ -30,8 +30,8 @@ def get_stdev_channels(quotes: Iterable[Quote],
             StdevChannelsResults is list of StdevChannelsResult with providing useful helper methods.
 
     See more:
-         - [Stdev Channels Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/StdDevChannels/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Stdev Channels Reference](https://python.stockindicators.dev/indicators/StdDevChannels/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetStdDevChannels[Quote](CsList(Quote, quotes), lookback_periods, standard_deviations)
     return StdevChannelsResults(results, StdevChannelsResult)

--- a/stock_indicators/indicators/stoch.py
+++ b/stock_indicators/indicators/stoch.py
@@ -32,8 +32,8 @@ def get_stoch(quotes: Iterable[Quote], lookback_periods: int = 14, signal_period
             StochResults is list of StochResult with providing useful helper methods.
 
     See more:
-         - [Stochastic Oscillator Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Stoch/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Stochastic Oscillator Reference](https://python.stockindicators.dev/indicators/Stoch/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     stoch_results = CsIndicator.GetStoch[Quote](CsList(Quote, quotes), lookback_periods, signal_periods, smooth_periods)
     return StochResults(stoch_results, StochResult)

--- a/stock_indicators/indicators/stoch_rsi.py
+++ b/stock_indicators/indicators/stoch_rsi.py
@@ -33,8 +33,8 @@ def get_stoch_rsi(quotes: Iterable[Quote], rsi_periods: int, stoch_periods: int,
             StochRSIResults is list of StochRSIResult with providing useful helper methods.
 
     See more:
-         - [Stochastic RSI Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/StochRsi/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Stochastic RSI Reference](https://python.stockindicators.dev/indicators/StochRsi/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     stoch_rsi_results = CsIndicator.GetStochRsi[Quote](CsList(Quote, quotes), rsi_periods, stoch_periods, signal_periods, smooth_periods)
     return StochRSIResults(stoch_rsi_results, StochRSIResult)

--- a/stock_indicators/indicators/super_trend.py
+++ b/stock_indicators/indicators/super_trend.py
@@ -32,8 +32,8 @@ def get_super_trend(quotes: Iterable[Quote], lookback_periods: int = 10, multipl
             SuperTrendResults is list of SuperTrendResult with providing useful helper methods.
 
     See more:
-         - [SuperTrend Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/SuperTrend/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [SuperTrend Reference](https://python.stockindicators.dev/indicators/SuperTrend/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     super_trend_results = CsIndicator.GetSuperTrend[Quote](CsList(Quote, quotes), lookback_periods, multiplier)
     return SuperTrendResults(super_trend_results, SuperTrendResult)

--- a/stock_indicators/indicators/t3.py
+++ b/stock_indicators/indicators/t3.py
@@ -28,8 +28,8 @@ def get_t3(quotes: Iterable[Quote], lookback_periods: int = 5,
             T3Results is list of T3Result with providing useful helper methods.
 
     See more:
-         - [T3 Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/T3/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [T3 Reference](https://python.stockindicators.dev/indicators/T3/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetT3[Quote](CsList(Quote, quotes), lookback_periods,
                                        volume_factor)

--- a/stock_indicators/indicators/tema.py
+++ b/stock_indicators/indicators/tema.py
@@ -25,8 +25,8 @@ def get_tema(quotes: Iterable[Quote], lookback_periods: int):
             TEMAResults is list of TEMAResult with providing useful helper methods.
 
     See more:
-         - [TEMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/TripleEma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [TEMA Reference](https://python.stockindicators.dev/indicators/TripleEma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetTema[Quote](CsList(Quote, quotes), lookback_periods)
     return TEMAResults(results, TEMAResult)

--- a/stock_indicators/indicators/trix.py
+++ b/stock_indicators/indicators/trix.py
@@ -28,8 +28,8 @@ def get_trix(quotes: Iterable[Quote], lookback_periods: int, signal_periods: Opt
             TRIXResults is list of TRIXResult with providing useful helper methods.
 
     See more:
-         - [TRIX Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Trix/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [TRIX Reference](https://python.stockindicators.dev/indicators/Trix/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetTrix[Quote](CsList(Quote, quotes), lookback_periods, signal_periods)
     return TRIXResults(results, TRIXResult)

--- a/stock_indicators/indicators/tsi.py
+++ b/stock_indicators/indicators/tsi.py
@@ -32,8 +32,8 @@ def get_tsi(quotes: Iterable[Quote], lookback_periods: int = 25,
             TSIResults is list of TSIResult with providing useful helper methods.
 
     See more:
-         - [TSI Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Tsi/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [TSI Reference](https://python.stockindicators.dev/indicators/Tsi/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetTsi[Quote](CsList(Quote, quotes), lookback_periods,
                                        smooth_periods, signal_periods)

--- a/stock_indicators/indicators/ulcer_index.py
+++ b/stock_indicators/indicators/ulcer_index.py
@@ -25,8 +25,8 @@ def get_ulcer_index(quotes: Iterable[Quote], lookback_periods: int = 14):
             UlcerIndexResults is list of UlcerIndexResult with providing useful helper methods.
 
     See more:
-         - [Ulcer Index Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/UlcerIndex/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Ulcer Index Reference](https://python.stockindicators.dev/indicators/UlcerIndex/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetUlcerIndex[Quote](CsList(Quote, quotes), lookback_periods)
     return UlcerIndexResults(results, UlcerIndexResult)

--- a/stock_indicators/indicators/ultimate.py
+++ b/stock_indicators/indicators/ultimate.py
@@ -32,8 +32,8 @@ def get_ultimate(quotes: Iterable[Quote], short_periods: int = 7,
             UltimateResults is list of UltimateResult with providing useful helper methods.
 
     See more:
-         - [Ultimate Oscillator Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Ultimate/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Ultimate Oscillator Reference](https://python.stockindicators.dev/indicators/Ultimate/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetUltimate[Quote](CsList(Quote, quotes), short_periods,
                                              middle_periods, long_periods)

--- a/stock_indicators/indicators/volatility_stop.py
+++ b/stock_indicators/indicators/volatility_stop.py
@@ -29,8 +29,8 @@ def get_volatility_stop(quotes: Iterable[Quote], lookback_periods: int = 7,
             VolatilityStopResults is list of VolatilityStopResult with providing useful helper methods.
 
     See more:
-         - [Volatility Stop Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/VolatilityStop/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Volatility Stop Reference](https://python.stockindicators.dev/indicators/VolatilityStop/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetVolatilityStop[Quote](CsList(Quote, quotes), lookback_periods,
                                                    multiplier)

--- a/stock_indicators/indicators/vortex.py
+++ b/stock_indicators/indicators/vortex.py
@@ -26,8 +26,8 @@ def get_vortex(quotes: Iterable[Quote], lookback_periods: int):
             VortexResults is list of VortexResult with providing useful helper methods.
 
     See more:
-         - [Vortex Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Vortex/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Vortex Reference](https://python.stockindicators.dev/indicators/Vortex/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetVortex[Quote](CsList(Quote, quotes), lookback_periods)
     return VortexResults(results, VortexResult)

--- a/stock_indicators/indicators/vwap.py
+++ b/stock_indicators/indicators/vwap.py
@@ -36,8 +36,8 @@ def get_vwap(quotes, start = None, month = 1, day = 1, hour = 0, minute = 0):
             VWAPResults is list of VWAPResult with providing useful helper methods.
 
     See more:
-         - [VWAP Fractal Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Vwap/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [VWAP Fractal Reference](https://python.stockindicators.dev/indicators/Vwap/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     if isinstance(start, int):
         start = datetime(start, month, day, hour, minute)

--- a/stock_indicators/indicators/vwma.py
+++ b/stock_indicators/indicators/vwma.py
@@ -25,8 +25,8 @@ def get_vwma(quotes: Iterable[Quote], lookback_periods: int):
             VWMAResults is list of VWMAResult with providing useful helper methods.
 
     See more:
-         - [VWMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Vwma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [VWMA Reference](https://python.stockindicators.dev/indicators/Vwma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetVwma[Quote](CsList(Quote, quotes), lookback_periods)
     return VWMAResults(results, VWMAResult)

--- a/stock_indicators/indicators/williams_r.py
+++ b/stock_indicators/indicators/williams_r.py
@@ -26,8 +26,8 @@ def get_williams_r(quotes: Iterable[Quote], lookback_periods: int = 14):
             WilliamsResults is list of WilliamsResult with providing useful helper methods.
 
     See more:
-         - [Williams %R Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/WilliamsR/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Williams %R Reference](https://python.stockindicators.dev/indicators/WilliamsR/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetWilliamsR[Quote](CsList(Quote, quotes), lookback_periods)
     return WilliamsResults(results, WilliamsResult)

--- a/stock_indicators/indicators/wma.py
+++ b/stock_indicators/indicators/wma.py
@@ -30,8 +30,8 @@ def get_wma(quotes: Iterable[Quote], lookback_periods: int,
             WMAResults is list of WMAResult with providing useful helper methods.
 
     See more:
-         - [WMA Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/Wma/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [WMA Reference](https://python.stockindicators.dev/indicators/Wma/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     quotes = Quote.use(quotes, candle_part) # Error occurs if not assigned to local var.
     results = CsIndicator.GetWma(quotes, lookback_periods)

--- a/stock_indicators/indicators/zig_zag.py
+++ b/stock_indicators/indicators/zig_zag.py
@@ -32,8 +32,8 @@ def get_zig_zag(quotes: Iterable[Quote], end_type: EndType = EndType.CLOSE,
             ZigZagResults is list of ZigZagResult with providing useful helper methods.
 
     See more:
-         - [Zig Zag Reference](https://daveskender.github.io/Stock.Indicators.Python/indicators/ZigZag/#content)
-         - [Helper Methods](https://daveskender.github.io/Stock.Indicators.Python/utilities/#content)
+         - [Zig Zag Reference](https://python.stockindicators.dev/indicators/ZigZag/#content)
+         - [Helper Methods](https://python.stockindicators.dev/utilities/#content)
     """
     results = CsIndicator.GetZigZag[Quote](CsList(Quote, quotes), end_type.cs_value,
                                            CsDecimal(percent_change))


### PR DESCRIPTION
This adds a manual Cloudflare pages deployer GitHub Action and related environment.  It prevents unnecessary deployments of the site on regular code changes and is triggered manually as needed.  Without this, docs would be out of sync when there's a merge to `main` that doesn't correspond to a tagged `pypi` package publish.

- [x] add GitHub Action to manually deploy docs site, as needed
- [x] update paths since we've deleted GitHub Pages