### PR TITLE
chore: Add PR title linter

### DIFF
--- a/.github/workflows/semantic-pr-linter.yml
+++ b/.github/workflows/semantic-pr-linter.yml
@@ -1,0 +1,70 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    name: validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+
+          # Configure additional validation for the subject based on a regex.
+          # We enforce that the subject starts with an uppercase character.
+          subjectPattern: ^([A-Z]).+$
+
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: >
+            The subject "**{subject}**" found in the pull request title "*{title}*"
+            didn't match the configured pattern. Please ensure that the subject
+            starts with an uppercase character.
+
+          # If the PR contains one of these newline-delimited labels, the
+          # validation is skipped. If you want to rerun the validation when
+          # labels change, you might want to use the `labeled` and `unlabeled`
+          # event triggers in your workflow.
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: >
+            ### Hey there and thank you for opening this pull request! 👋🏼
+
+            It looks like your proposed **_Pull request title_** needs to be adjusted.
+
+            >🚩 **Error** » ${{ steps.lint_pr_title.outputs.error_message }}
+
+            #### Pull request title naming convention
+
+            Our PR title name taxonomy is `type: Subject`, where **type** is typically
+            *feat*, *fix*, or *chore*, and **subject** is a phrase (proper noun) that starts with a capitalized letter.
+            The *chore* type usually has a subject that starts with an action verb like *Add* or *Update*.
+            Examples: `feat: Admin portal login`, `fix: Divide by zero bug in SMA`, and `chore: Update user docs`.
+            See the [Conventional Commits specification](https://www.conventionalcommits.org) for more information.
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
@LeeDongGeon1996 I've noticed you like to use use Conventional Commit standards for PR titles (merge commits).  You've inspired me to add this linter to the Indicator repos.  See https://github.com/DaveSkender/Stock.Indicators/pull/1136 for more information on the implementation.  I didn't add many constraints, kept it fairly flexible.