### PR TITLE
ci: Rename doc-website environment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,7 @@ name: Deploy website
 on: [workflow_dispatch]
 
 concurrency:
-  group: cloudflare-pages
+  group: docs-website
 
 env:
   JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     environment:
-      name: cloudflare-pages
+      name: docs-website
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Renaming the documentation site environment name GitHub Action, to be more descriptive.