### PR TITLE
ci: Update tool installers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,17 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v3
         with:
+          cache: true
           dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-quality: "ga"
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
+          cache: "pip"
           python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies


### PR DESCRIPTION
Updating build tool installers, enabling caching.  We were getting deprecation warnings.