### PR TITLE
docs: Remove broken test coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![image](https://raw.githubusercontent.com/DaveSkender/Stock.Indicators.Python/main/docs/assets/social-banner.png)](https://python.stockindicators.dev/)
 
 [![PyPI](https://img.shields.io/pypi/v/stock-indicators?color=blue&label=PyPI)](https://badge.fury.io/py/stock-indicators)
-[![code coverage](https://img.shields.io/azure-devops/coverage/skender/stock.indicators/26/main?logo=AzureDevOps&label=Test%20Coverage)](https://dev.azure.com/skender/Stock.Indicators/_build/latest?definitionId=26&branchName=main&view=codecoverage-tab)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/stock-indicators?style=flat&logo=Python&logoColor=white&label=Downloads&color=indigo&link=https%3A%2F%2Fpypistats.org%2Fpackages%2Fstock-indicators)
 
 # Stock Indicators for Python

--- a/docs/_indicators/HeikinAshi.md
+++ b/docs/_indicators/HeikinAshi.md
@@ -31,7 +31,6 @@ HeikinAshiResults[HeikinAshiResult]
 - `HeikinAshiResults` is just a list of `HeikinAshiResult`.
 - It always returns the same number of elements as there are in the historical quotes.
 - It does not return a single incremental indicator value.
-- The first period will have `None` values since there's not enough data to calculate.
 
 ### HeikinAshiResult
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,10 +7,6 @@ layout: page
 
 # Contributing guidelines
 
-[![build status](https://img.shields.io/azure-devops/build/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/26/main?logo=AzureDevops&label=Build%20Status)](https://dev.azure.com/skender/Stock.Indicators/_build/latest?definitionId=26&branchName=main)
-[![code coverage](https://img.shields.io/azure-devops/coverage/skender/stock.indicators/26/main?logo=AzureDevOps&label=Code%20Coverage)](https://dev.azure.com/skender/Stock.Indicators/_build/latest?definitionId=26&branchName=main&view=codecoverage-tab)
-![CodeQL](https://github.com/DaveSkender/Stock.Indicators.Python/workflows/CodeQL/badge.svg)
-
 **Thanks for taking the time to contribute!**
 
 This project is simpler than most, so it's a good place to start contributing to the open source community, even if you're a newbie.

--- a/docs/pages/guide.md
+++ b/docs/pages/guide.md
@@ -90,7 +90,7 @@ See [individual indicator pages]({{site.baseurl}}/indicators/) for specific usag
 
 More examples available:
 
-- [Demo site](https://stock-charts.azurewebsites.net) (a stock chart)
+- [Demo site](https://charts.stockindicators.dev) (a stock chart)
 
 ## Historical quotes
 

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -11,9 +11,6 @@ lazy-images: true
 <a href="https://pypi.org/project/stock-indicators" aria-label="Get the PyPI package." class="not-mobile">
   <img src="https://img.shields.io/pypi/v/stock-indicators?color=blue&label=PyPI&cacheSeconds=259200" alt="" />
 </a>
-<a href="https://dev.azure.com/skender/Stock.Indicators/_build/latest?definitionId=26&branchName=main&view=codecoverage-tab" aria-label="Read more about our code coverage." class="not-mobile">
-  <img src="https://img.shields.io/azure-devops/coverage/skender/stock.indicators/26/main?logo=AzureDevOps&label=Test%20Coverage&cacheSeconds=259200" alt="" />
-</a>
 <a href="https://pypistats.org/packages/stock-indicators" aria-label="See PyPi download stats." class="not-mobile">
   <img src="https://img.shields.io/pypi/dm/stock-indicators?style=flat&logo=Python&logoColor=white&label=Downloads&color=indigo&link=https%3A%2F%2Fpypistats.org%2Fpackages%2Fstock-indicators" alt="" />
 </a>

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -27,7 +27,7 @@ Explore more information:
 - [Guide and Pro tips]({{site.baseurl}}/guide/#content)
 - [Indicators and overlays]({{site.baseurl}}/indicators/#content)
 - [Utilities and Helpers]({{site.baseurl}}/utilities/#content)
-- [Demo site](https://stock-charts.azurewebsites.net) (a stock chart)
+- [Demo site](https://charts.stockindicators.dev) (a stock chart)
 - [Release notes]({{site.github.repository_url}}/releases)
 - [Discussions]({{site.dotnet.repo}}/discussions)
 - [Contributing guidelines]({{site.baseurl}}/contributing/#content)


### PR DESCRIPTION
I disabled Azure DevOps since we’re not using it anymore.
It broke the legacy badge.