### PR TITLE
fix: Wrap exception to add helpful exception message

### DIFF
--- a/stock_indicators/_cslib/__init__.py
+++ b/stock_indicators/_cslib/__init__.py
@@ -15,9 +15,8 @@ try:
     load(runtime="coreclr")
     import clr
 except Exception as e:
-    e.add_note("Stock Indicators for Python has a dependency on CLR.\n"
-               "Install .NET SDK 6.0 (or newer) in your environment to add the required CLR capability.")
-    raise e
+    raise ImportError("Stock Indicators for Python has a dependency on CLR.\n"
+                      "Install .NET SDK 6.0 (or newer) in your environment to add the required CLR capability.") from e
 
 skender_stock_indicators_dll_path = os.path.join(
     os.path.dirname(__file__),

--- a/stock_indicators/_cstypes/decimal.py
+++ b/stock_indicators/_cstypes/decimal.py
@@ -21,9 +21,8 @@ class Decimal:
         try:
             return CsDecimal.Parse(str(decimal))
         except CsFormatException as e:
-            e.add_note("You may be using numeric data that is incompatible with your locale environment settings.\n"
-                       "For example, you may be using decimal points instead of commas.")
-            raise e
+            raise ValueError("You may be using numeric data that is incompatible with your locale environment settings.\n"
+                             "For example, you may be using decimal points instead of commas.") from e
 
 
 def to_pydecimal(cs_decimal):


### PR DESCRIPTION
### Description

 - Wrap exception for adding exception message
 - `add_note()` not supported in Python 3.8 


### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
