### PR TITLE
docs: Update example snippet (cosmetic)

### DIFF
--- a/docs/GemFile.lock
+++ b/docs/GemFile.lock
@@ -254,7 +254,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
-    public_suffix (5.0.4)
+    public_suffix (5.0.5)
     racc (1.7.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)

--- a/docs/_indicators/Adl.md
+++ b/docs/_indicators/Adl.md
@@ -59,7 +59,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate
 results = indicators.get_adl(quotes)

--- a/docs/_indicators/Adx.md
+++ b/docs/_indicators/Adx.md
@@ -60,7 +60,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 14-period ADX
 results = indicators.get_adx(quotes, lookback_periods)

--- a/docs/_indicators/Alligator.md
+++ b/docs/_indicators/Alligator.md
@@ -64,7 +64,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate the Williams Alligator
 results = indicators.get_alligator(quotes)

--- a/docs/_indicators/Alma.md
+++ b/docs/_indicators/Alma.md
@@ -57,7 +57,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate Alma
 results = indicators.get_alma(quotes, 10, 0.5, 6)

--- a/docs/_indicators/Aroon.md
+++ b/docs/_indicators/Aroon.md
@@ -57,7 +57,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 results = indicators.get_aroon(quotes, lookback_periods)
 ```

--- a/docs/_indicators/Atr.md
+++ b/docs/_indicators/Atr.md
@@ -64,7 +64,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 14-period ATR
 results = indicators.get_atr(quotes, 14)

--- a/docs/_indicators/Awesome.md
+++ b/docs/_indicators/Awesome.md
@@ -58,7 +58,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate
 results = indicators.get_awesome(quotes, 5, 34)

--- a/docs/_indicators/Beta.md
+++ b/docs/_indicators/Beta.md
@@ -76,8 +76,8 @@ from stock_indicators import indicators
 from stock_indicators import BetaType      # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-history_SPX = get_history_from_feed("SPX")
-history_TSLA = get_history_from_feed("TSLA")
+history_SPX = get_historical_quotes("SPX")
+history_TSLA = get_historical_quotes("TSLA")
 
 # calculate 20-period Beta coefficient
 results = indicators.get_beta(history_SPX, history_TSLA, 20, BetaType.STANDARD)

--- a/docs/_indicators/BollingerBands.md
+++ b/docs/_indicators/BollingerBands.md
@@ -61,7 +61,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate BollingerBands(20, 2)
 results = indicators.get_bollinger_bands(quotes, 20, 2)

--- a/docs/_indicators/Bop.md
+++ b/docs/_indicators/Bop.md
@@ -56,7 +56,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 14-period BOP
 results = indicators.get_bop(quotes, 14)

--- a/docs/_indicators/Cci.md
+++ b/docs/_indicators/Cci.md
@@ -55,7 +55,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period CCI
 results = indicators.get_cci(quotes, 20)

--- a/docs/_indicators/ChaikinOsc.md
+++ b/docs/_indicators/ChaikinOsc.md
@@ -63,7 +63,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period Chaikin Oscillator
 results = indicators.get_chaikin_osc(quotes, 20)

--- a/docs/_indicators/Chandelier.md
+++ b/docs/_indicators/Chandelier.md
@@ -69,7 +69,7 @@ from stock_indicators import indicators
 from stock_indicators import ChandelierType     # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate Chandelier(22,3)
 results = indicators.get_chandelier(quotes, 22, 3, ChandelierType.LONG)

--- a/docs/_indicators/Chop.md
+++ b/docs/_indicators/Chop.md
@@ -55,7 +55,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate CHOP(14)
 results = indicators.get_chop(quotes, 14)

--- a/docs/_indicators/Cmf.md
+++ b/docs/_indicators/Cmf.md
@@ -59,7 +59,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period CMF
 results = indicators.get_cmf(quotes, 20)

--- a/docs/_indicators/ConnorsRsi.md
+++ b/docs/_indicators/ConnorsRsi.md
@@ -62,7 +62,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate ConnorsRsi(3,2.100)
 results = indicators.get_connors_rsi(quotes, 3, 2, 100)

--- a/docs/_indicators/Correlation.md
+++ b/docs/_indicators/Correlation.md
@@ -61,8 +61,8 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes_spx = get_history_from_feed("SPX")
-quotes_tsla = get_history_from_feed("TSLA")
+quotes_spx = get_historical_quotes("SPX")
+quotes_tsla = get_historical_quotes("TSLA")
 
 # Calculate 20-period Correlation
 results = indicators.get_correlation(quotes_spx, quotes_tsla, 20)

--- a/docs/_indicators/Dema.md
+++ b/docs/_indicators/Dema.md
@@ -57,7 +57,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 20-period DEMA
 results = indicators.get_dema(quotes, 20)

--- a/docs/_indicators/Doji.md
+++ b/docs/_indicators/Doji.md
@@ -52,7 +52,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate
 results = indicators.get_doji(quotes);

--- a/docs/_indicators/Donchian.md
+++ b/docs/_indicators/Donchian.md
@@ -59,7 +59,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate Donchian(20)
 results = indicators.get_donchian(quotes, 20)

--- a/docs/_indicators/Dpo.md
+++ b/docs/_indicators/Dpo.md
@@ -56,7 +56,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate
 results = indicators.get_dpo(quotes, 14)

--- a/docs/_indicators/ElderRay.md
+++ b/docs/_indicators/ElderRay.md
@@ -60,7 +60,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate ElderRay(13)
 results = indicators.get_elder_ray(quotes, 13)

--- a/docs/_indicators/Ema.md
+++ b/docs/_indicators/Ema.md
@@ -61,7 +61,7 @@ from stock_indicators import indicators
 from stock_indicators import CandlePart     # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 20-period EMA
 results = indicators.get_ema(quotes, 20, CandlePart.CLOSE)

--- a/docs/_indicators/Epma.md
+++ b/docs/_indicators/Epma.md
@@ -56,7 +56,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period EPMA
 results = indicators.get_epma(quotes, 20)

--- a/docs/_indicators/Fcb.md
+++ b/docs/_indicators/Fcb.md
@@ -58,7 +58,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate Fcb(14)
 results = indicators.get_fcb(quotes, 14)

--- a/docs/_indicators/FisherTransform.md
+++ b/docs/_indicators/FisherTransform.md
@@ -63,7 +63,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 10-period FisherTransform
 results = indicators.get_fisher_transform(quotes, 10)

--- a/docs/_indicators/ForceIndex.md
+++ b/docs/_indicators/ForceIndex.md
@@ -57,7 +57,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate ForceIndex(13)
 results = indicators.get_force_index(quotes, 13)

--- a/docs/_indicators/Fractal.md
+++ b/docs/_indicators/Fractal.md
@@ -75,7 +75,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate Fractal
 results = indicators.get_fractal(quotes, 5)

--- a/docs/_indicators/Gator.md
+++ b/docs/_indicators/Gator.md
@@ -61,7 +61,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate the Gator Oscillator
 results = indicators.get_gator(quotes)

--- a/docs/_indicators/HeikinAshi.md
+++ b/docs/_indicators/HeikinAshi.md
@@ -57,7 +57,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate
 results = indicators.get_heikin_ashi(quotes)

--- a/docs/_indicators/Hma.md
+++ b/docs/_indicators/Hma.md
@@ -55,7 +55,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period HMA
 results = indicators.get_hma(quotes, 20)

--- a/docs/_indicators/HtTrendline.md
+++ b/docs/_indicators/HtTrendline.md
@@ -59,7 +59,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate HT Trendline
 results = indicators.get_ht_trendline(quotes)

--- a/docs/_indicators/Hurst.md
+++ b/docs/_indicators/Hurst.md
@@ -57,7 +57,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period Hurst
 results = indicators.get_hurst(quotes, 20)

--- a/docs/_indicators/Ichimoku.md
+++ b/docs/_indicators/Ichimoku.md
@@ -73,7 +73,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate ICHIMOKU(9,26,52)
 results = indicators.get_ichimoku(quotes, 9, 26, 52)

--- a/docs/_indicators/Kama.md
+++ b/docs/_indicators/Kama.md
@@ -62,7 +62,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate KAMA(10,2,30)
 results = indicators.get_kama(quotes, 10,2,30)

--- a/docs/_indicators/Keltner.md
+++ b/docs/_indicators/Keltner.md
@@ -62,7 +62,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate Keltner(20)
 results = indicators.get_keltner(quotes, 20,2.0,10)

--- a/docs/_indicators/Kvo.md
+++ b/docs/_indicators/Kvo.md
@@ -60,7 +60,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate Klinger(34,55,13)
 results = indicators.get_kvo(quotes, 34, 55, 13)

--- a/docs/_indicators/MaEnvelopes.md
+++ b/docs/_indicators/MaEnvelopes.md
@@ -83,7 +83,7 @@ from stock_indicators import indicators
 from stock_indicators import MAType     # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period SMA envelopes with 2.5% offset
 results = indicators.get_ma_envelopes(quotes, 20, 2.5, MAType.SMA);

--- a/docs/_indicators/Macd.md
+++ b/docs/_indicators/Macd.md
@@ -66,7 +66,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate MACD(12,26,9)
 results = indicators.get_macd(quotes, 12, 26, 9)

--- a/docs/_indicators/Mama.md
+++ b/docs/_indicators/Mama.md
@@ -59,7 +59,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate Mama(0.5,0.05)
 results = indicators.get_mama(quotes, 0.5,0.05)

--- a/docs/_indicators/Marubozu.md
+++ b/docs/_indicators/Marubozu.md
@@ -52,7 +52,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate
 results = indicators.get_marubozu(quotes);

--- a/docs/_indicators/Mfi.md
+++ b/docs/_indicators/Mfi.md
@@ -55,7 +55,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate
 results = indicators.get_mfi(quotes, 14)

--- a/docs/_indicators/Obv.md
+++ b/docs/_indicators/Obv.md
@@ -58,7 +58,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate
 results = indicators.get_obv(quotes)

--- a/docs/_indicators/ParabolicSar.md
+++ b/docs/_indicators/ParabolicSar.md
@@ -62,7 +62,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate ParabolicSar(0.02,0.2)
 results = indicators.get_parabolic_sar(quotes, 0.02, 0.2)

--- a/docs/_indicators/PivotPoints.md
+++ b/docs/_indicators/PivotPoints.md
@@ -94,7 +94,7 @@ from stock_indicators import indicators
 from stock_indicators import PeriodSize, PivotPointType      # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate Woodie-style month-based Pivot Points
 results = indicators.get_pivot_points(quotes, PeriodSize.MONTH, PivotPointType.WOODIE);

--- a/docs/_indicators/Pivots.md
+++ b/docs/_indicators/Pivots.md
@@ -91,7 +91,7 @@ from stock_indicators import indicators
 from stock_indicators import EndType     # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate Pivots(2,2,20) using High/Low values
 results = indicators.get_pivots(quotes, 2, 2, 20, EndType.HIGH_LOW);

--- a/docs/_indicators/Pmo.md
+++ b/docs/_indicators/Pmo.md
@@ -58,7 +58,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period PMO
 results = indicators.get_pmo(quotes, 35,20,10)

--- a/docs/_indicators/Prs.md
+++ b/docs/_indicators/Prs.md
@@ -58,8 +58,8 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-history_SPX = get_history_from_feed("SPX")
-history_TSLA = get_history_from_feed("TSLA")
+history_SPX = get_historical_quotes("SPX")
+history_TSLA = get_historical_quotes("TSLA")
 
 # Calculate 14-period PRS
 results = indicators.get_prs(history_SPX, history_TSLA, 14)

--- a/docs/_indicators/Pvo.md
+++ b/docs/_indicators/Pvo.md
@@ -61,7 +61,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate Pvo(12,26,9)
 results = indicators.get_pvo(quotes, 12, 26, 9);

--- a/docs/_indicators/Renko.md
+++ b/docs/_indicators/Renko.md
@@ -77,7 +77,7 @@ from stock_indicators import indicators
 from stock_indicators import EndType     # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate
 results = indicators.get_renko(quotes, 2.5, EndType.CLOSE);
@@ -119,7 +119,7 @@ RenkoResults[RenkoResult]
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate
 results = indicators.get_renko_atr(quotes, atr_periods);

--- a/docs/_indicators/Roc.md
+++ b/docs/_indicators/Roc.md
@@ -59,7 +59,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 20-period ROC
 results = indicators.get_roc(quotes, 20)

--- a/docs/_indicators/RollingPivots.md
+++ b/docs/_indicators/RollingPivots.md
@@ -80,7 +80,7 @@ from stock_indicators import indicators
 from stock_indicators import PivotPointType     # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate Woodie-style 14 period Rolling Pivot Points
 results = indicators.get_rolling_pivots(quotes, 14, 0, PivotPointType.Woodie);

--- a/docs/_indicators/Rsi.md
+++ b/docs/_indicators/Rsi.md
@@ -58,7 +58,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate RSI(14)
 results = indicators.get_rsi(quotes, 14)

--- a/docs/_indicators/Slope.md
+++ b/docs/_indicators/Slope.md
@@ -61,7 +61,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 20-period Slope
 results = indicators.get_slope(quotes, 20)

--- a/docs/_indicators/Sma.md
+++ b/docs/_indicators/Sma.md
@@ -59,7 +59,7 @@ from stock_indicators import indicators
 from stock_indicators import CandlePart     # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 20-period SMA
 results = indicators.get_sma(quotes, 20, CandlePart.CLOSE)

--- a/docs/_indicators/Smi.md
+++ b/docs/_indicators/Smi.md
@@ -61,7 +61,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate SMI(14,20,5,3)
 results = indicators.get_smi(quotes, 14, 20, 5, 3)

--- a/docs/_indicators/Smma.md
+++ b/docs/_indicators/Smma.md
@@ -58,7 +58,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period SMMA
 results = indicators.get_smma(quotes, 20)

--- a/docs/_indicators/StarcBands.md
+++ b/docs/_indicators/StarcBands.md
@@ -61,7 +61,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate StarcBands(20)
 results = indicators.get_starc_bands(quotes, 20, 2.0, 10)

--- a/docs/_indicators/Stc.md
+++ b/docs/_indicators/Stc.md
@@ -59,7 +59,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate STC(12,26,9)
 results = indicators.get_stc(quotes, 10, 23, 50)

--- a/docs/_indicators/StdDev.md
+++ b/docs/_indicators/StdDev.md
@@ -60,7 +60,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 10-period Standard Deviation
 results = indicators.get_stdev(quotes, 10)

--- a/docs/_indicators/StdDevChannels.md
+++ b/docs/_indicators/StdDevChannels.md
@@ -61,7 +61,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate StdDevChannels(20,2)
 results = indicators.get_stdev_channels(quotes, 20,2)

--- a/docs/_indicators/Stoch.md
+++ b/docs/_indicators/Stoch.md
@@ -77,7 +77,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate STO %K(14),%D(3) (slow)
 results = indicators.get_stoch(quotes, 14, 3, 3)

--- a/docs/_indicators/StochRsi.md
+++ b/docs/_indicators/StochRsi.md
@@ -63,7 +63,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate StochRSI
 results = indicators.get_stoch_rsi(quotes, 14, 14, 1, 1)

--- a/docs/_indicators/SuperTrend.md
+++ b/docs/_indicators/SuperTrend.md
@@ -62,7 +62,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate SuperTrend(14,3)
 results = indicators.get_super_trend(quotes, 14, 3)

--- a/docs/_indicators/T3.md
+++ b/docs/_indicators/T3.md
@@ -58,7 +58,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 5-period T3
 results = indicators.get_t3(quotes, 5, 0.7)

--- a/docs/_indicators/Tema.md
+++ b/docs/_indicators/Tema.md
@@ -57,7 +57,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 20-period TEMA
 results = indicators.get_tema(quotes, 20)

--- a/docs/_indicators/Trix.md
+++ b/docs/_indicators/Trix.md
@@ -60,7 +60,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 20-period Trix
 results = indicators.get_trix(quotes, 14)

--- a/docs/_indicators/Tsi.md
+++ b/docs/_indicators/Tsi.md
@@ -61,7 +61,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period TSI
 results = indicators.get_tsi(quotes, 25, 13, 7)

--- a/docs/_indicators/UlcerIndex.md
+++ b/docs/_indicators/UlcerIndex.md
@@ -55,7 +55,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate UI(14)
 results = indicators.get_ulcer_index(quotes, 14)

--- a/docs/_indicators/Ultimate.md
+++ b/docs/_indicators/Ultimate.md
@@ -57,7 +57,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # calculate 20-period Ultimate
 results = indicators.get_ultimate(quotes, 7, 14, 28)

--- a/docs/_indicators/VolatilityStop.md
+++ b/docs/_indicators/VolatilityStop.md
@@ -63,7 +63,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate VolatilityStop(20,2.5)
 results = indicators.get_volatility_stop(quotes, 20, 2.5)

--- a/docs/_indicators/Vortex.md
+++ b/docs/_indicators/Vortex.md
@@ -56,7 +56,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 14-period VI
 results = indicators.get_vortex(quotes, 14);

--- a/docs/_indicators/Vwap.md
+++ b/docs/_indicators/Vwap.md
@@ -59,7 +59,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate
 results = indicators.get_vwap(quotes);

--- a/docs/_indicators/Vwma.md
+++ b/docs/_indicators/Vwma.md
@@ -55,7 +55,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 10-period VWMA
 results = indicators.get_vwma(quotes, 10)

--- a/docs/_indicators/WilliamsR.md
+++ b/docs/_indicators/WilliamsR.md
@@ -55,7 +55,7 @@ See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 from stock_indicators import indicators
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate WilliamsR(14)
 results = indicators.get_williams_r(quotes, 14)

--- a/docs/_indicators/Wma.md
+++ b/docs/_indicators/Wma.md
@@ -59,7 +59,7 @@ from stock_indicators import indicators
 from stock_indicators import CandlePart     # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 20-period WMA
 results = indicators.get_wma(quotes, 20, CandlePart.CLOSE)

--- a/docs/_indicators/ZigZag.md
+++ b/docs/_indicators/ZigZag.md
@@ -76,7 +76,7 @@ from stock_indicators import indicators
 from stock_indicators import EndType     # Short path, version >= 0.8.1
 
 # This method is NOT a part of the library.
-quotes = get_history_from_feed("SPY")
+quotes = get_historical_quotes("SPY")
 
 # Calculate 3% change ZIGZAG
 results = indicators.get_zig_zag(quotes, EndType.CLOSE, 3);

--- a/docs/pages/guide.md
+++ b/docs/pages/guide.md
@@ -25,9 +25,7 @@ layout: page
 
 1. Install prerequisite framework dependencies
 
-    Stock Indicators for Python has dependency on on the [Common Language Runtime (CLR)](https://learn.microsoft.com/dotnet/standard/clr).  You'll need to install the .NET SDK in your environment to get required CLR capability.
-
-    Check that you've installed the following prerequisite software:
+    Stock Indicators for Python has dependency on on the [Common Language Runtime (CLR)](https://learn.microsoft.com/dotnet/standard/clr).  You'll need to install the .NET SDK in your environment to get required CLR capability. Check that you've installed the following prerequisite software:
 
     > Install **Python** and the **.NET SDK**.  Use the latest versions for better performance.
 
@@ -38,7 +36,7 @@ layout: page
 
     Note: we do not support the open source [Mono .NET Framework](https://www.mono-project.com).
 
-2. Find and install the **stock-indicators** Python package into your environment.
+2. Install the **stock-indicators** Python package into your environment.
 
     ```bash
     # bash CLI command
@@ -47,16 +45,11 @@ layout: page
 
     > See [Python documentation](https://packaging.python.org/en/latest/tutorials/installing-packages/) for more help with installing packages.
 
-> **More help**: if you're still having trouble getting started, see our
-> **[QuickStart guide](https://github.com/DaveSkender/Stock.Indicators.Python.QuickStart#readme)**
-> for step-by-step instructions to setup up your environment,
-> and for calculating your first indicator using this library.
-
 ### Prerequisite data
 
 Most indicators require that you provide historical quote data and additional configuration parameters.
 
-You must get historical quotes from your own market data provider.  For clarification, the `get_history_from_feed()` method shown in the example below and throughout our documentation **is not part of this library**, but rather an example to represent your own acquisition of historical quotes.
+You must get historical quotes from your own market data provider.  For clarification, the `get_historical_quotes()` method shown in the example below and throughout our documentation **is not part of this library**, but rather an example to represent your own acquisition of historical quotes.
 
 Historical price data can be provided as an `Iterable`(such as `List` or an object having `__iter__()`) of the `Quote` class or its sub-class ([see below](#historical-quotes)); be aware that you **have to** inherit `Quote` class when you [make custom quote class](#using-custom-quote-classes).
 
@@ -93,9 +86,12 @@ SMA on 2018-04-26 was $255.9705
 
 See [individual indicator pages]({{site.baseurl}}/indicators/) for specific usage guidance.
 
-More examples available:
-
-- [Demo site](https://charts.stockindicators.dev) (a stock chart)
+> **More help**: if you're having trouble getting started, see our
+> **[QuickStart guide](https://github.com/DaveSkender/Stock.Indicators.Python.QuickStart#readme)**
+> for step-by-step instructions to setup up your environment,
+> and for calculating your first indicator using this library.
+>
+> We also have a [demo site](https://charts.stockindicators.dev) (a stock chart) where you can visualize and experiment with different indicator settings.
 
 ## Historical quotes
 
@@ -178,7 +174,7 @@ class MyCustomQuote(Quote):
 from stock_indicators import indicators
 
 # fetch historical quotes from your favorite feed
-quotes: Iterable[MyCustomQuote] = get_history_from_feed("MSFT");
+quotes: Iterable[MyCustomQuote] = get_historical_quotes("MSFT");
 
 # example: get 20-period simple moving average
 results = indicators.get_sma(quotes, 20);
@@ -215,7 +211,7 @@ class ExtendedEMA(EMAResult):
         return f"EMA on {self.date.date()} was ${self.ema or 0:.4f}"
     
 # compute indicator
-quotes = get_history_from_feed("MSFT")
+quotes = get_historical_quotes("MSFT")
 results = indicators.get_ema(quotes, 20)
 
 # 1. list[ExtendedEMA]
@@ -244,7 +240,7 @@ If you want to compute an indicator of indicators, such as an SMA of an ADX or a
 from stock_indicators import indicators
 
 # fetch historical quotes from your feed (your method)
-quotes = get_history_from_feed("MSFT")
+quotes = get_historical_quotes("MSFT")
 
 # calculate EMA
 results = indicators.get_ema(quotes, 20)

--- a/docs/pages/utilities.md
+++ b/docs/pages/utilities.md
@@ -46,7 +46,7 @@ Currently, `.to_quotes()` is only available on a select few indicators.  If you 
 
 ```python
 # fetch historical quotes from your favorite feed
-quotes = get_history_from_feed("MSFT")
+quotes = get_historical_quotes("MSFT")
 
 # calculate indicator series
 results = indicators.get_ema(quotes, 20)


### PR DESCRIPTION
The guide was saying:

> the `get_history_from_feed()` method shown in the example below and throughout our documentation **is not part of this library**

but then follows with a code snippet that used `get_historical_quotes()` inconsistently.  I've updated them all to use the latter, since it's a bit nicer/simpler than "from feed".

