### PR TITLE
ci: Disable test reporter

### DIFF
--- a/.github/workflows/test-indicators.yml
+++ b/.github/workflows/test-indicators.yml
@@ -55,16 +55,16 @@ jobs:
         if: env.IS_PRIMARY == 'true'
         run: pytest -vr A tests --junitxml=test-results.xml
 
-      - name: Convert test file
-        if: env.IS_PRIMARY == 'true'
-        run: |
-          dotnet tool install --global trx2junit
-          trx2junit test-results.xml --junit2trx
+      # - name: Convert test file
+      #   if: env.IS_PRIMARY == 'true'
+      #   run: |
+      #     dotnet tool install --global trx2junit
+      #     trx2junit test-results.xml --junit2trx
 
-      - name: Post test summary
-        uses: bibipkins/dotnet-test-reporter@v1.4.1
-        if: env.IS_PRIMARY == 'true' && always()
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-title: ""
-          results-path:  test-results.trx
+      # - name: Post test summary
+      #   uses: bibipkins/dotnet-test-reporter@v1.4.1
+      #   if: env.IS_PRIMARY == 'true' && always()
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     comment-title: ""
+      #     results-path:  test-results.trx


### PR DESCRIPTION
Disabling the test-reporter portion of unit tests due to contributor permissions issues; it's always been a bit flaky.
