### PR TITLE
chore: Bump faraday from 2.14.0 to 2.14.1 in Gemfile.lock

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.10.0)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger


### PR DESCRIPTION
Update packages