### PR TITLE
fix: Update CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,78 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-# CodeRabbit config docs: https://docs.coderabbit.ai/reference/configuration
-# Defaults and examples GitHub repo: coderabbitai/awesome-coderabbit
+inheritance: true
 
-# General settings
-language: "en-US"            # Language for reviews (default: "en-US")
-tone_instructions: ""        # Custom tone for reviews (default: "")
-enable_free_tier: false      # Enable free tier features (default: true)
-inheritance: false           # top-level instructions (default: false)
-
-# preview features
-early_access: true           # Enable early-access features (default: false)
-
-# ISSUE ENRICHMENT (preview)
-issue_enrichment:
-  auto_enrich:
-    enabled: false           # Enable auto issue enrichment (default: true)
-  planning:
-    enabled: true            # Enable generating a planning for issues (default: true)
-    auto_planning:
-      enabled: true          # Enable auto-generated plans based on labels (default: true)
-      labels:                # Triggering labels for auto-planning (default: [])
-        - rabbit-plan
-  labeling:
-    auto_apply_labels: false
-    labeling_instructions: []
-
-# REVIEWS
 reviews:
-  profile: "chill"
-  review_status: true
-  commit_status: true
-  fail_commit_status: false
-  request_changes_workflow: false
-  enable_prompt_for_ai_agents: true
-  in_progress_fortune: false
-
-  abort_on_close: true
-  disable_cache: false
-
-  # High level summary of the changes in the PR/MR description or walkthrough.
-  high_level_summary: false
-  high_level_summary_in_walkthrough: false
-  high_level_summary_placeholder: "@coderabbitai summary"
-
-  # Walkthrough
-  collapse_walkthrough: true
-  changed_files_summary: false         # Generate a summary of the changed files in the walkthrough.
-  sequence_diagrams: false             # Generate sequence diagrams in the walkthrough.
-  estimate_code_review_effort: false   # Generate review effort in walkthrough.
-  assess_linked_issues: true           # Assess how well the changes address the linked issues in the walkthrough.
-  related_issues: false                # Include possibly related issues in the walkthrough.
-  related_prs: false                   # Include possibly related pull requests in the walkthrough.
-  poem: false                          # Generate a poem in the walkthrough comment.
-
-  # Automatic review scheduling
-  auto_review:
-    enabled: true
-    auto_incremental_review: true      # Review each push (default: true)
-    drafts: false                      # Review Draft pull requests (default: false)
-    base_branches:
-      - ".*"
-
-  # Automatic labels
-  # Suggest labels based on the changes in the pull request in the walkthrough.
-  suggested_labels: false
-  auto_apply_labels: false
-
-  # Automatic reviewers
-  # Suggest reviewers based on the changes in the pull request in the walkthrough.
-  suggested_reviewers: false
-  auto_assign_reviewers: false
-
-  # Automatic PR titles
-  auto_title_placeholder: "@coderabbitai"
   auto_title_instructions: |
     Use conventional commit with short (<65 chars) sentence case Subject.  See Copilot instructions.
 
@@ -95,7 +24,6 @@ reviews:
     - `docs: Improve API examples` (not "Update documentation files")
     - `chore: Update dependencies` (when that's the sole purpose)
 
-  # Path specific review instructions
   path_instructions:
     - path: "**/src/**"
       instructions: "Ensure alignment to latest language and framework standards, and our organization's coding standards"
@@ -106,172 +34,41 @@ reviews:
     - path: "**/*.md"
       instructions: "Check for broken links and formatting according to markdown configuration and instructions"
 
-  # Code enhancement features
-  finishing_touches:
-    docstrings:
-      enabled: false         # Generate docstrings for PRs/MRs (default: true)
-    unit_tests:
-      enabled: false         # Generate unit tests for PRs/MRs (default: true)
-
-  # Pre-merge validation checks
-  pre_merge_checks:
-    docstrings:              # Docstring coverage check (default: warning)
-      mode: off
-    description:             # PR description validation (default: warning)
-      mode: off
-    issue_assessment:        # Linked issue assessment (default: warning)
-      mode: off
-    title:                   # PR title validation (default: warning)
-      mode: off
-
-  # Files to include/exclude from reviews
   path_filters:
-    - "**"                   # Include all (base)
-    - "!node_modules/"       # NPM dependencies
-    - "!*-lock.json"         # NPM/PNPM lock files
-    - "!packages.lock.json"  # NuGet lock file
-    - "!packages/"           # NuGet packages cache
-    - "!_cslib/"             # DLL library path
-    - "!.jekyll-cache/"      # Jekyll cache
-    - "!.pytest_cache/"      # Python test cache
-    - "!__pycache__/"        # Python caches
-    - "!.venv/"              # Python virtual env
-    - "!.benchmarks/"        # Benchmarks cache
-    - "!.coverage/"          # Code coverage reports
-    - "!vendor/"             # Ruby vendor and gem files
-    - "!Gemfile.lock"        # Ruby dependencies lock
-    - "!.vitepress/cache/"   # VitePress cache
-    - "!.vitepress/dist/"    # VitePress build output
-    - "!bin/"                # .NET build output
-    - "!obj/"                # .NET build intermediate files
-    - "!*.g.cs"              # Generated source code
-    - "!*.docx"              # Office Word
-    - "!*.pptx"              # Office PowerPoint
-    - "!*.xlsx"              # Office Spreadsheets
-    - "!*.bak"               # Backup files
-    - "!*.zip"               # Compressed files
+    - "**"
+    - "!.github/workflows/*.lock.yml"
+    - "!node_modules/"
+    - "!*-lock.json"
+    - "!packages.lock.json"
+    - "!packages/"
+    - "!_cslib/"
+    - "!.jekyll-cache/"
+    - "!.pytest_cache/"
+    - "!__pycache__/"
+    - "!.venv/"
+    - "!.benchmarks/"
+    - "!.coverage/"
+    - "!vendor/"
+    - "!Gemfile.lock"
+    - "!.vitepress/cache/"
+    - "!.vitepress/dist/"
+    - "!bin/"
+    - "!obj/"
+    - "!*.g.cs"
+    - "!*.docx"
+    - "!*.pptx"
+    - "!*.xlsx"
+    - "!*.bak"
+    - "!*.zip"
 
-  # Tool integrations
   tools:
-
-    # tools: default on
-    actionlint:              # GitHub Actions workflow static checker
-      enabled: true
-    ast-grep:                # Code pattern analysis using AST
-      essential_rules: true
-    gitleaks:                # Secret/credential scanner
-      enabled: true
-    github-checks:           # GitHub Checks integration
-      enabled: true
-      timeout_ms: 90000
-    markdownlint:            # Markdown linter for consistency
-      enabled: true
-    osvScanner:              # Vulnerability package scanner
-      enabled: true
-    ruff:                    # Python linter and formatter
-      enabled: true
-    semgrep:                 # Security & code quality static analysis
-      enabled: true
-    shellcheck:              # Shell script linter
-      enabled: true
-    yamllint:                # YAML linter
+    ruff:
       enabled: true
 
-    # tools: default off
-    biome:                   # Fast formatter, linter, and analyzer for web
-      enabled: false
-    brakeman:                # Rails security vulnerability scanner
-      enabled: false
-    buf:                     # Protobuf linter
-      enabled: false
-    checkov:                 # Infrastructure-as-code static analyzer
-      enabled: false
-    checkmake:               # Makefile linter
-      enabled: false
-    circleci:                # CircleCI config static checker
-      enabled: false
-    clang:                   # C/C++ static analysis tool
-      enabled: false
-    clippy:                  # Rust linter
-      enabled: false
-    cppcheck:                # C/C++ static analyzer
-      enabled: false
-    detekt:                  # Kotlin static analyzer
-      enabled: false
-    dotenvLint:              # .env file linter
-      enabled: false
-    eslint:                  # JavaScript/TypeScript linter
-      enabled: false
-    flake8:                  # Python linter
-      enabled: false
-    fortitudeLint:           # Fortran linter
-      enabled: false
-    golangci-lint:           # Go linter runner
-      enabled: false
-    hadolint:                # Dockerfile linter
-      enabled: false
-    htmlhint:                # HTML linter
-      enabled: false
-    languagetool:            # Grammar and style checker (30+ languages)
-      enabled: false
-    luacheck:                # Lua linter
-      enabled: false
-    oxc:                     # JavaScript/TypeScript linter in Rust
-      enabled: false
-    phpcs:                   # PHP linter and coding standard checker
-      enabled: false
-    phpmd:                   # PHP code quality analyzer
-      enabled: false
-    phpstan:                 # PHP static analysis tool
-      enabled: false
-    pmd:                     # Java/multilanguage static analyzer
-      enabled: false
-    prismaLint:              # Prisma schema linter
-      enabled: false
-    pylint:                  # Python static analyzer
-      enabled: false
-    regal:                   # Rego linter and language server
-      enabled: false
-    rubocop:                 # Ruby linter and code formatter
-      enabled: false
-    shopifyThemeCheck:       # Shopify Liquid theme linter
-      enabled: false
-    sqlfluff:                # SQL linter
-      enabled: false
-    swiftlint:               # Swift linter
-      enabled: false
-
-# CHAT FEATURES
-chat:
-  art: false
-  auto_reply: true
-  integrations:
-    jira:
-      usage: disabled
-    linear:
-      usage: disabled
-
-# KNOWLEDGE BASE
 knowledge_base:
-  opt_out: false
-  web_search:
-    enabled: true
   code_guidelines:
-    enabled: true
     filePatterns:
       - "**/agents.md"
       - ".github/copilot-instructions.md"
       - ".github/instructions/**/*.instructions.md"
       - ".github/skills/**/*skill.md"
-  learnings:
-    scope: auto
-  issues:
-    scope: auto
-  pull_requests:
-    scope: auto
-  mcp:
-    usage: auto
-  jira:
-    usage: disabled
-  linear:
-    usage: disabled

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -68,7 +68,5 @@ reviews:
 knowledge_base:
   code_guidelines:
     filePatterns:
-      - "**/agents.md"
-      - ".github/copilot-instructions.md"
-      - ".github/instructions/**/*.instructions.md"
-      - ".github/skills/**/*skill.md"
+      - "**/AGENTS.md"
+      - ".github/skills/**"


### PR DESCRIPTION
## Summary

Updates `.coderabbit.yaml` to properly participate in the facioquo org inheritance model.

### Changes
- Set `inheritance: true` (was `false`) — now inherits org baseline from `facioquo/coderabbit`
- Removed `issue_enrichment` block — inherited from org, which already has `agentic-planning` label configured
- Removed all review settings that duplicate org defaults (profile, booleans, auto_review, finishing_touches, pre_merge_checks, chat)
- Retained Python-specific deltas: `ruff: enabled: true`, extended `path_filters`, `path_instructions`, `auto_title_instructions`, `knowledge_base.code_guidelines.filePatterns`

Closes the stale `rabbit-plan` label reference (label was already renamed on GitHub in a prior batch update).